### PR TITLE
Adds a streaming mode.

### DIFF
--- a/packages/demo-react-js/copy-internal-deps.sh
+++ b/packages/demo-react-js/copy-internal-deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cp ../reactotron-react-js/dist/index.js node_modules/reactotron-react-js/index.js
-cp ../reactotron-core-client/dist/*.js node_modules/reactotron-core-client/
-cp ../reactotron-redux/dist/*.js node_modules/reactotron-redux/
-cp ../reactotron-apisauce/dist/*.js node_modules/reactotron-apisauce/
+cp ../reactotron-react-js/dist/index.js ./node_modules/reactotron-react-js/index.js
+cp ../reactotron-core-client/dist/index.js ./node_modules/reactotron-core-client/index.js
+cp ../reactotron-redux/dist/index.js ./node_modules/reactotron-redux/index.js
+cp ../reactotron-apisauce/dist/index.js ./node_modules/reactotron-apisauce/index.js

--- a/packages/reactotron-app/App/Foundation/Header.js
+++ b/packages/reactotron-app/App/Foundation/Header.js
@@ -30,6 +30,7 @@ class Header extends Component {
       <div style={Styles.container}>
         <div style={Styles.content}>
           <div style={Styles.tabs}>
+            <Tab tabId='streaming' text='STREAMING' onPress={ui.switchTabToStreaming} />
             <Tab tabId='logging' text='LOGGING' onPress={ui.switchTabToLogging} />
             <Tab tabId='state' text='STATE' onPress={ui.switchTabToState} />
             <Tab tabId='network' text='NETWORK' onPress={ui.switchTabToNetwork} />

--- a/packages/reactotron-app/App/Foundation/VisualRoot.js
+++ b/packages/reactotron-app/App/Foundation/VisualRoot.js
@@ -7,6 +7,7 @@ import PageNetworking from '../Network/PageNetworking'
 import Footer from './Footer'
 import Colors from '../Theme/Colors'
 import AppStyles from '../Theme/AppStyles'
+import PageStreaming from '../Streaming/PageStreaming'
 
 const Styles = {
   container: {
@@ -23,6 +24,7 @@ export default class VisualRoot extends Component {
     return (
       <div style={Styles.container}>
         <Header />
+        {/*
         <Page tabId='logging'>
           <PageLogging />
         </Page>
@@ -31,6 +33,10 @@ export default class VisualRoot extends Component {
         </Page>
         <Page tabId='network'>
           <PageNetworking />
+        </Page>
+        */}
+        <Page tabId='streaming'>
+          <PageStreaming />
         </Page>
         <Footer />
       </div>

--- a/packages/reactotron-app/App/Shared/ObjectTree.js
+++ b/packages/reactotron-app/App/Shared/ObjectTree.js
@@ -1,0 +1,46 @@
+import React, { Component, PropTypes } from 'react'
+import JSONTree from 'react-json-tree'
+import Colors from '../Theme/Colors'
+
+const Styles = {
+  container: {
+  },
+  theme: {
+    tree: {
+      backgroundColor: 'transparent',
+      fontSize: 14
+    },
+    label: {
+      color: Colors.text
+    },
+    arrowSign: {
+      borderTopColor: Colors.text,
+      color: Colors.text
+    }
+  }
+}
+
+class ObjectTree extends Component {
+
+  static propTypes = {
+    object: PropTypes.oneOf([PropTypes.object, PropTypes.array]),
+    level: PropTypes.number
+  }
+
+  render () {
+    const { object, level = 1 } = this.props
+    return (
+      <div style={Styles.container}>
+        <JSONTree
+          data={object}
+          hideRoot
+          shouldExpandNode={(keyName, data, minLevel) => minLevel <= level}
+          theme={Styles.theme}
+        />
+      </div>
+    )
+  }
+
+}
+
+export default ObjectTree

--- a/packages/reactotron-app/App/Shared/Timestamp.js
+++ b/packages/reactotron-app/App/Shared/Timestamp.js
@@ -6,10 +6,11 @@ const Styles = {
   container: {
     fontSize: 13,
     margin: 0,
-    padding: 0
+    padding: 0,
+    color: Colors.text
   },
-  left: { color: Colors.text },
-  right: { color: Colors.text }
+  left: {},
+  right: {}
 }
 
 class Timestamp extends Component {
@@ -21,7 +22,7 @@ class Timestamp extends Component {
 
   render () {
     const date = moment(this.props.date)
-    const left = date.format('hh:mm:')
+    const left = date.format('h:mm:')
     // const right = date.format('ss.SS')
     const right = date.format('ss A')
     const containerStyles = {...Styles.container, ...this.props.style}

--- a/packages/reactotron-app/App/State/PageState.js
+++ b/packages/reactotron-app/App/State/PageState.js
@@ -1,35 +1,60 @@
 import React, { Component } from 'react'
-import { observer, inject } from 'mobx-react'
+import { observer } from 'mobx-react'
 import AppStyles from '../Theme/AppStyles'
 import Colors from '../Theme/Colors'
 import SideMenu from '../Shared/SideMenu'
+import StateActionList from './StateActionList'
+
+const column = {
+  flex: 1,
+  paddingLeft: 10,
+  paddingRight: 10,
+  overflowY: 'scroll',
+
+}
 
 const Styles = {
   container: {
-    ...AppStyles.Layout.vbox
-  },
-  content: {
-    ...AppStyles.Layout.vbox,
+    ...AppStyles.Layout.hbox,
     backgroundColor: Colors.screen,
-    paddingLeft: 200,
-    paddingRight: 150,
+    paddingLeft: 10,
+    paddingRight: 10,
     paddingTop: 0,
     paddingBottom: 0,
-    overflowY: 'scroll',
     marginRight: 4
+  },
+  actions: {
+    ...column
+  },
+  rightSide: {
+    ...AppStyles.Layout.vbox
+  },
+  queries: {
+    ...column
+  },
+  watches: {
+    ...column
+  },
+  title: {
+    fontSize: 20,
+    textAlign: 'center'
   }
 }
 
-@inject('session')
 @observer
 class PageLogging extends Component {
 
   render () {
     return (
       <div style={Styles.container}>
-        <SideMenu />
-        <div style={Styles.content}>
-          State
+        <div style={Styles.actions}>
+          <h1 style={Styles.title}>Completed Actions</h1>
+          <StateActionList />
+        </div>
+        <div style={Styles.rightSide}>
+          <div style={Styles.watches}>
+            <h1 style={Styles.title}>Watches</h1>
+          </div>
         </div>
       </div>
     )

--- a/packages/reactotron-app/App/State/StateAction.js
+++ b/packages/reactotron-app/App/State/StateAction.js
@@ -1,0 +1,54 @@
+import React, { Component, PropTypes } from 'react'
+import Colors from '../Theme/Colors'
+import AppStyles from '../Theme/AppStyles'
+import Timestamp from '../Shared/Timestamp'
+import { observer } from 'mobx-react'
+import ObjectTree from '../Shared/ObjectTree'
+
+const Styles = {
+  container: {
+    borderBottom: `1px solid ${Colors.line}`,
+    marginBottom: 8,
+    marginTop: 8,
+    paddingTop: 0,
+    paddingBottom: 16,
+    ...AppStyles.Layout.vbox
+  },
+  ms: {
+    margin: 0,
+    padding: 0
+  },
+  action: {
+    margin: 0,
+    padding: 0,
+    color: Colors.primary
+  },
+  timestamp: {
+    fontSize: 17
+  }
+}
+
+@observer
+class StateAction extends Component {
+
+  static propTypes = {
+    stateAction: PropTypes.object.isRequired
+  }
+
+  render () {
+    const { stateAction } = this.props
+    const { payload, date } = stateAction
+    const { name, action, ms } = payload
+    return (
+      <div style={Styles.container}>
+        <Timestamp date={date} style={Styles.timestamp} />
+        <p style={Styles.ms}>{ms} ms</p>
+        <p style={Styles.action}>{name}</p>
+        <ObjectTree object={{action}} />
+      </div>
+    )
+  }
+
+}
+
+export default StateAction

--- a/packages/reactotron-app/App/State/StateActionList.js
+++ b/packages/reactotron-app/App/State/StateActionList.js
@@ -1,0 +1,39 @@
+import { map } from 'ramda'
+import { observer, inject } from 'mobx-react'
+import React, { Component, PropTypes } from 'react'
+import Colors from '../Theme/Colors'
+import AppStyles from '../Theme/AppStyles'
+import StateAction from './StateAction'
+
+const Styles = {
+  container: {
+    paddingTop: 20,
+    paddingBottom: 20
+  },
+  message: {
+  },
+  level: {
+  }
+}
+
+@inject('session')
+@observer
+class StateActionList extends Component {
+
+  static propTypes = {
+  }
+
+  render () {
+    const { server } = this.props.session
+    const stateActions = server.commands['state.action.complete']
+    const renderItem = stateAction => <StateAction key={stateAction.messageId} stateAction={stateAction} />
+    return (
+      <div style={Styles.container}>
+        {map(renderItem, stateActions)}
+      </div>
+    )
+  }
+
+}
+
+export default StateActionList

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -8,7 +8,7 @@ class UI {
   /**
    * Which tab are we on?
    */
-  @observable tab = 'logging'
+  @observable tab = 'streaming'
 
   /**
    * Which state tab are we on?
@@ -21,9 +21,10 @@ class UI {
   constructor (server) {
     this.server = server
 
-    Mousetrap.bind('command+1', this.switchTabToLogging)
-    Mousetrap.bind('command+2', this.switchTabToState)
-    Mousetrap.bind('command+3', this.switchTabToNetwork)
+    Mousetrap.bind('command+1', this.switchTabToStreaming)
+    Mousetrap.bind('command+2', this.switchTabToLogging)
+    Mousetrap.bind('command+3', this.switchTabToState)
+    Mousetrap.bind('command+4', this.switchTabToNetwork)
     Mousetrap.bind('command+k', this.reset)
 
     // holy shit, this works.
@@ -32,6 +33,10 @@ class UI {
       // this.stateTab = 'search'
       // this.showStateFindDialog = true
     })
+  }
+
+  @action switchTabToStreaming = () => {
+    this.tab = 'streaming'
   }
 
   @action switchTabToLogging = () => {

--- a/packages/reactotron-app/App/Streaming/Command.js
+++ b/packages/reactotron-app/App/Streaming/Command.js
@@ -1,0 +1,103 @@
+import React, { Component, PropTypes } from 'react'
+import Colors from '../Theme/Colors'
+import AppStyles from '../Theme/AppStyles'
+import Timestamp from '../Shared/Timestamp'
+import { observer } from 'mobx-react'
+import { isNilOrEmpty } from 'ramdasauce'
+import { is, merge } from 'ramda'
+
+const Styles = {
+  container: {
+    ...AppStyles.Layout.hbox,
+    marginBottom: 8,
+    marginTop: 8,
+    paddingTop: 16,
+    paddingBottom: 16,
+    marginLeft: 10,
+    marginRight: 10,
+    alignItems: 'flex-start'
+  },
+  body: {
+    ...AppStyles.Layout.vbox,
+    marginLeft: 10
+  },
+  topRow: {
+    ...AppStyles.Layout.hbox,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+    paddingBottom: 4,
+    borderBottom: `1px solid ${Colors.subtleLine}`
+  },
+  title: {
+    fontSize: 16,
+    color: Colors.primary,
+    textAlign: 'left'
+  },
+  subtitle: {
+    fontSize: 14,
+    color: Colors.mutedText,
+    textAlign: 'left',
+    paddingLeft: 8
+  },
+  duration: {
+    fontSize: 14,
+    color: Colors.primary,
+    paddingRight: 4
+  },
+  timestamp: {
+    fontSize: 14,
+    color: Colors.line
+  },
+  spacer: {
+    flex: 1
+  },
+  children: {
+    minHeight: 40,
+    overflow: 'hidden'
+  }
+}
+
+@observer
+class Command extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    subtitle: PropTypes.string,
+    duration: PropTypes.number
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    return this.props.command !== nextProps.command
+  }
+
+  render () {
+    const { command, children, title, subtitle, duration, color = Colors.primary } = this.props
+    const hasSubtitle = !isNilOrEmpty(subtitle)
+    const hasDuration = is(Number, duration)
+    const ms = hasDuration && Number(duration).toFixed(0)
+    const { date } = command
+    const titleStyle = merge(Styles.title, { color })
+    const topRowStyle = merge(Styles.topRow, { borderBottomColor: color })
+    return (
+      <div style={Styles.container}>
+        <div style={Styles.body}>
+          <div style={topRowStyle}>
+            <span style={titleStyle}>{title}</span>
+            {hasSubtitle && <span style={Styles.subtitle}>{subtitle}</span>}
+            <span style={Styles.spacer}></span>
+            {hasDuration && <span style={Styles.duration}>{ms} ms</span>}
+            <Timestamp date={date} style={Styles.timestamp} />
+          </div>
+          <div style={Styles.children}>
+            {children}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+}
+
+export default Command

--- a/packages/reactotron-app/App/Streaming/CommandIcon.js
+++ b/packages/reactotron-app/App/Streaming/CommandIcon.js
@@ -1,0 +1,61 @@
+import React, { Component, PropTypes } from 'react'
+import BenchmarkIcon from 'react-icons/lib/md/assignment-turned-in'
+import DebugIcon from 'react-icons/lib/md/info'
+import WarningIcon from 'react-icons/lib/md/warning'
+import ErrorIcon from 'react-icons/lib/md/error'
+import ActionIcon from 'react-icons/lib/md/check-box'
+import UnknownIcon from 'react-icons/lib/md/block'
+import Colors from '../Theme/Colors'
+
+const Styles = {
+  container: {
+
+  },
+  iconColor: Colors.Palette.grey,
+  iconSize: 40
+}
+
+const benchmark = <BenchmarkIcon size={Styles.iconSize} color={Styles.iconColor} />
+const debug = <DebugIcon size={Styles.iconSize} color={Styles.iconColor} />
+const warning = <WarningIcon size={Styles.iconSize} color={Styles.iconColor} />
+const error = <ErrorIcon size={Styles.iconSize} color={Styles.iconColor} />
+const action = <ActionIcon size={Styles.iconSize} color={Styles.iconColor} />
+const unknown = <UnknownIcon size={Styles.iconSize} color={Styles.iconColor} />
+
+const getIcon = (command) => {
+  const { type, payload } = command
+
+  switch (type) {
+    case 'benchmark.report': return benchmark
+    case 'state.action.complete': return action
+    case 'log':
+      const { level } = payload
+      switch (level) {
+        case 'warn': return warning
+        case 'error': return error
+        default: return debug
+      }
+
+    default: return unknown
+  }
+}
+
+class CommandIcon extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  render () {
+    const { command } = this.props
+    const icon = getIcon(command)
+
+    return (
+      <div style={Styles.container}>
+        {icon}
+      </div>
+    )
+  }
+}
+
+export default CommandIcon

--- a/packages/reactotron-app/App/Streaming/CommandList.js
+++ b/packages/reactotron-app/App/Streaming/CommandList.js
@@ -1,0 +1,43 @@
+import { reverse, map } from 'ramda'
+import { observer, inject } from 'mobx-react'
+import React, { Component, PropTypes } from 'react'
+import Colors from '../Theme/Colors'
+import AppStyles from '../Theme/AppStyles'
+import Command from './Command'
+import getCommandComponent from './Commands'
+
+const Styles = {
+  container: {
+    paddingTop: 0,
+    paddingBottom: 20
+  },
+  message: {
+  },
+  level: {
+  }
+}
+
+@inject('session')
+@observer
+class CommandList extends Component {
+
+  static propTypes = {
+  }
+
+  render () {
+    const { server } = this.props.session
+    const all = reverse(server.commands.all)
+    const renderItem = command => {
+      const CommandComponent = getCommandComponent(command)
+      return <CommandComponent key={command.messageId} command={command} />
+    }
+    return (
+      <div style={Styles.container}>
+        {map(renderItem, all)}
+      </div>
+    )
+  }
+
+}
+
+export default CommandList

--- a/packages/reactotron-app/App/Streaming/Commands/ApiResponseCommand.js
+++ b/packages/reactotron-app/App/Streaming/Commands/ApiResponseCommand.js
@@ -1,0 +1,113 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Command'
+import ObjectTree from '../../Shared/ObjectTree'
+import { dotPath, isWithin } from 'ramdasauce'
+import { map, toUpper, toPairs } from 'ramda'
+import AppStyles from '../../Theme/AppStyles'
+import Colors from '../../Theme/Colors'
+
+const Styles = {
+  container: {
+  },
+  method: {},
+  status: {},
+  url: {
+    wordBreak: 'break-all',
+    paddingBottom: 10,
+    paddingTop: 10
+  },
+  headerTitle: {
+    margin: 0,
+    padding: 0,
+    paddingTop: 8,
+    paddingBottom: 0,
+  },
+  headerKey: {
+    minWidth: 150,
+    width: 150,
+    wordBreak: 'break-all',
+  },
+  headerValue: {
+    flex: 1,
+    wordBreak: 'break-all'
+  },
+  row: {
+    fontSize: 14,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    WebkitUserSelect: 'all'
+  },
+  pre: {
+    whiteSpace: 'pre-wrap'
+  }
+
+}
+
+const makeRow = ([key, value]) => {
+  return (
+    <div key={key} style={Styles.row}>
+      <div style={Styles.headerKey}>{key}</div>
+      <div style={Styles.headerValue}>{value}</div>
+    </div>
+  )
+}
+
+const makeTable = headers => (
+  <div>
+    {map(makeRow, toPairs(headers))}
+  </div>
+)
+
+class ApiResponseCommand extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  renderDataAsObjectTree (data) {
+    return <ObjectTree object={data} level={0} />
+  }
+
+  renderDataAsPreTag (data) {
+    const stringified = JSON.stringify(data, 2, 2)
+    return <pre style={Styles.pre}>{stringified}</pre>
+  }
+
+  renderData (data) {
+    return this.renderDataAsObjectTree(data)
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload } = command
+    const { duration } = payload
+    const status = dotPath('response.status', payload)
+    const ok = isWithin(200, 299, status || 0)
+    const url = dotPath('request.url', payload)
+    const method = toUpper(dotPath('request.method', payload) || '')
+    const requestHeaders = dotPath('request.headers', payload)
+    const responseHeaders = dotPath('response.headers', payload)
+    const body = dotPath('response.body', payload)
+    const color = ok ? Colors.good : Colors.error
+    const title = 'API RESPONSE'
+    const subtitle = `${status} - ${method}`
+
+    return (
+      <Command command={command} title={title} subtitle={subtitle} duration={duration} color={color}>
+        <div style={Styles.container}>
+          <div style={Styles.url}>{url}</div>
+          <h4 style={Styles.headerTitle}>Request Headers</h4>
+          {makeTable(requestHeaders)}
+          <h4 style={Styles.headerTitle}>Response Headers</h4>
+          {makeTable(responseHeaders)}
+          <h4 style={Styles.headerTitle}>Body</h4>
+          {this.renderData(body)}
+
+        </div>
+      </Command>
+    )
+  }
+}
+
+export default ApiResponseCommand

--- a/packages/reactotron-app/App/Streaming/Commands/LogCommand.js
+++ b/packages/reactotron-app/App/Streaming/Commands/LogCommand.js
@@ -1,0 +1,75 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Command'
+import ObjectTree from '../../Shared/ObjectTree'
+import { map, trim, split } from 'ramda'
+import Colors from '../../Theme/Colors'
+
+const getName = level => {
+  switch (level) {
+    case 'debug': return 'DEBUG'
+    case 'warn': return 'WARNING'
+    case 'error': return 'ERROR'
+    default: return 'LOG'
+  }
+}
+
+const breakIntoSpans = (part) => {
+  return (
+    <span>{part}<br /></span>
+  )
+}
+
+const formatMessage = message => {
+  if (typeof message === 'string') {
+    return (
+      <div>
+        {map(breakIntoSpans, split('\n', trim(message)))}
+      </div>
+    )
+  } else if (typeof message === 'object') {
+    <ObjectTree object={{payload: message}} />
+  }
+}
+
+const Styles = {
+  container: {
+    paddingTop: 4
+  }
+}
+
+class LogCommand extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload } = command
+    const { level } = payload
+    const title = getName(level)
+    let color
+    switch (level) {
+      case 'warn':
+        color = Colors.warning
+        break
+
+      case 'error':
+        color = Colors.error
+        break
+
+      default:
+        color = Colors.primary
+    }
+
+    return (
+      <Command command={command} title={title} color={color}>
+        <div style={Styles.container}>
+          {formatMessage(payload.message)}
+        </div>
+      </Command>
+    )
+  }
+}
+
+export default LogCommand

--- a/packages/reactotron-app/App/Streaming/Commands/StateActionCompleteCommand.js
+++ b/packages/reactotron-app/App/Streaming/Commands/StateActionCompleteCommand.js
@@ -1,0 +1,34 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Command'
+import ObjectTree from '../../Shared/ObjectTree'
+
+const Styles = {
+  name: {
+    margin: 0,
+    padding: 0
+  }
+}
+
+class StateActionComplete extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload } = command
+    const { ms, action, name } = payload
+
+    return (
+      <Command command={command} title='ACTION' duration={ms}>
+        <div style={Styles.container}>
+          <span style={Styles.name}>{name}</span>
+          <ObjectTree object={{action}} />
+        </div>
+      </Command>
+    )
+  }
+}
+
+export default StateActionComplete

--- a/packages/reactotron-app/App/Streaming/Commands/UnknownCommand.js
+++ b/packages/reactotron-app/App/Streaming/Commands/UnknownCommand.js
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Command'
+import ObjectTree from '../../Shared/ObjectTree'
+import Colors from '../../Theme/Colors'
+
+class UnknownCommand extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload, type } = command
+
+    return (
+      <Command command={command} title='MYSTERY 👻' subtitle={type} color={Colors.Palette.matteBlack}>
+        <ObjectTree object={{payload}} />
+      </Command>
+    )
+  }
+}
+
+export default UnknownCommand

--- a/packages/reactotron-app/App/Streaming/Commands/index.js
+++ b/packages/reactotron-app/App/Streaming/Commands/index.js
@@ -1,0 +1,16 @@
+import LogCommand from './LogCommand'
+import UnknownCommand from './UnknownCommand'
+import StateActionCompleteCommand from './StateActionCompleteCommand'
+import ApiResponseCommand from './ApiResponseCommand'
+
+export default command => {
+  const { type } = command
+
+  switch (type) {
+    case 'benchmark.report': return UnknownCommand
+    case 'log': return LogCommand
+    case 'state.action.complete': return StateActionCompleteCommand
+    case 'api.response': return ApiResponseCommand
+    default: return UnknownCommand
+  }
+}

--- a/packages/reactotron-app/App/Streaming/PageStreaming.js
+++ b/packages/reactotron-app/App/Streaming/PageStreaming.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import { observer } from 'mobx-react'
+import AppStyles from '../Theme/AppStyles'
+import Colors from '../Theme/Colors'
+import CommandList from './CommandList'
+
+const Styles = {
+  container: {
+    ...AppStyles.Layout.vbox,
+    backgroundColor: Colors.screen,
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingTop: 0,
+    paddingBottom: 0,
+    overflowY: 'scroll'
+  }
+}
+
+@observer
+class PageStreaming extends Component {
+
+  render () {
+    return (
+      <div style={Styles.container}>
+        <CommandList />
+      </div>
+    )
+  }
+
+}
+
+export default PageStreaming

--- a/packages/reactotron-app/App/Theme/Colors.js
+++ b/packages/reactotron-app/App/Theme/Colors.js
@@ -23,6 +23,7 @@ const roles = {
   text: Palette.matteBlack,
   mutedText: Palette.grey,
   line: Palette.dimGrey,
+  subtleLine: Palette.lightGrey,
   good: Palette.green,
   error: Palette.red,
   warning: Palette.orange

--- a/packages/reactotron-core-client/scripts/send.js
+++ b/packages/reactotron-core-client/scripts/send.js
@@ -16,6 +16,8 @@ const sendBenchmark = async (title) => {
   await sleep(100)
   bench.stop()
 }
+const sendAction = (action) =>
+  client.send('state.action.complete', { ms: 123, name: action.type, action })
 
 // send a bunch of messages
 const shotgun = async () => {
@@ -28,27 +30,41 @@ const shotgun = async () => {
       { firstName: 'Liam', lastName: 'Kellock' }
     ]
   })
+  sendAction({ type: 'SLEEP_REQUEST', duration: 50 })
   await sleep(50)
+  sendAction({ type: 'SLEEP_FINISHED', success: true })
   sendWarn('Warning: This is an almost an error. Beware!')
   await sleep(100)
   sendError('Attention! Things just got real.')
   await sleep(100)
-  sendDebug(`
-   Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   \n\n
-   Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
-   Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
-   I hope you enjoy.  Thank you.  And have a wonderful day. \
-   `)
+  const giant = `
+  Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  \n\n
+  Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
+  Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  Here\'s another debug message.  This one is a little longer just to see what wrapping looks like. \
+  I hope you enjoy.  Thank you.  And have a wonderful day. \
+  `
+  sendAction({ type: 'POST_GIANT_MESSAGE', message: giant })
+  sendAction({ type: 'OBJECTS_LOLS', theGoods: {
+    cities: ['Toronto', 'Halifax'],
+    towns: ['Tiny', 'Pictou'],
+    thingsAroundMyOffice: { 'htc': 'vive', 'yeti': 'blue' },
+    trueThing: true,
+    falseThing: false,
+    undefinedThing: undefined,
+    nullThing: null,
+    symbolThing: Symbol('hi')
+  }})
+  sendDebug(giant)
   await sendBenchmark('Awesome!')
 
   client.socket.close()

--- a/packages/reactotron-core-server/src/commands.js
+++ b/packages/reactotron-core-server/src/commands.js
@@ -4,6 +4,7 @@ import CommandTypes from './types'
 
 // how many commands we're allowed to have stored at one time (per-list)
 export const DEFAULT_MAXIMUM_LIST_SIZE = 100
+export const ALL_MAXIMUM_LIST_SIZE = 1000
 
 /**
  * Holds the lists of commands.
@@ -13,14 +14,14 @@ export const DEFAULT_MAXIMUM_LIST_SIZE = 100
 class Commands {
 
   /**
-   * Enforces a maximum list size.
+   * It's all the comands.  Like all of them.
    */
-  @observable maximumListSize
+  @observable all = asFlat([])
 
   /**
    * Constructor with an optional overrideable max list size.
    */
-  constructor (maximumListSize = DEFAULT_MAXIMUM_LIST_SIZE) {
+  constructor (maximumListSize = DEFAULT_MAXIMUM_LIST_SIZE, allMaximumListSize = ALL_MAXIMUM_LIST_SIZE) {
     // create an observable list for each (named after the type)
     R.forEach(type => {
       extendObservable(this, {
@@ -29,6 +30,7 @@ class Commands {
       // this[type] = observable([])
     }, CommandTypes)
     this.maximumListSize = maximumListSize
+    this.allMaximumListSize = allMaximumListSize
   }
 
   /**
@@ -41,6 +43,12 @@ class Commands {
     const list = this[type]
     // but if we can't, jet
     if (R.isNil(list)) return
+    // add this to the all list
+    this.all.push(command)
+    // enforce the all cap
+    if (this.all.length > this.allMaximumListSize) {
+      this.all.shift()
+    }
     // add this new one on the end
     list.push(command)
     // shift off the head of the list if we've filled up

--- a/packages/reactotron-core-server/src/index.js
+++ b/packages/reactotron-core-server/src/index.js
@@ -1,7 +1,7 @@
 import R from 'ramda'
 import Commands from './commands'
 import validate from './validation'
-import { observable, computed } from 'mobx'
+import { observable, computed, asFlat } from 'mobx'
 import defaultTransport from './transport'
 
 const DEFAULTS = {
@@ -40,7 +40,7 @@ class Server {
   /**
    * Holds the currently connected clients.
    */
-  @observable connections = []
+  @observable connections = asFlat([])
 
   /**
    * How many people are connected?
@@ -110,6 +110,7 @@ class Server {
         // for client intros
         if (type === 'client.intro') {
           const partialConnection = R.find(R.propEq('id', id), partialConnections)
+          fullCommand.payload.address = partialConnection.address
           partialConnections = R.without([partialConnection], partialConnections)
           // bestow the payload onto the connection
           const connection = { ...partialConnection, ...payload }

--- a/packages/reactotron-core-server/src/transport.js
+++ b/packages/reactotron-core-server/src/transport.js
@@ -1,12 +1,12 @@
 import socketIO from 'socket.io'
-import R from 'ramda'
+import R, { without } from 'ramda'
 
 export default ({ port, onConnect, onDisconnect, onCommand }) => {
   // hey, it's us!  a SocketIO Server!
   const io = socketIO(port)
 
   // a list of our connections
-  const connections = []
+  let connections = []
 
   // the object to return which has our transport interface
   const transport = {}
@@ -39,7 +39,7 @@ export default ({ port, onConnect, onDisconnect, onCommand }) => {
     socket.on('disconnect', () => {
       onDisconnect(id)
       // remove them from the list
-      connections.remove(transportConnection)
+      without([transportConnection], connections)
     })
 
     // when we receive a command from the client

--- a/packages/reactotron-core-server/test/commands-test.js
+++ b/packages/reactotron-core-server/test/commands-test.js
@@ -1,42 +1,47 @@
 import test from 'ava'
 import Commands from '../src/commands'
 import CommandTypes from '../src/types'
-import R from 'ramda'
+import { length, map, forEach } from 'ramda'
 
 test('has the right set of lists', t => {
   const c = new Commands()
-  t.plan(R.length(CommandTypes))
-  R.forEach(key => t.truthy(c[key]), CommandTypes)
+  t.plan(length(CommandTypes))
+  forEach(key => t.truthy(c[key]), CommandTypes)
 })
 
 test('added to the right list', t => {
-  t.plan(3 * R.length(CommandTypes))
+  t.plan(3 * length(CommandTypes) + 1)
   const c = new Commands()
-  R.map(type => {
+  map(type => {
     const action = { type }
     t.is(c[type].length, 0)
     c.addCommand(action)
     t.is(c[type].length, 1)
     t.deepEqual(c[type][0], action)
   }, CommandTypes)
+  t.is(c.all.length, length(CommandTypes))
 })
 
 test('enforces a max list size', t => {
-  t.plan(5)
+  t.plan(9)
   const type = 'log'
   // set a low cap for testing
-  const c = new Commands(1)
+  const c = new Commands(1, 1)
 
   // starts empty
   t.is(c[type].length, 0)
+  t.is(c.all.length, 0)
 
   // adds 1 as normal
   c.addCommand({ type, payload: 1 })
   t.is(c[type].length, 1)
+  t.is(c.all.length, 1)
   t.deepEqual(c[type][0], { type, payload: 1 })
 
   // now add another and ensure the first is pushed off
   c.addCommand({ type, payload: 2 })
   t.is(c[type].length, 1)
+  t.is(c.all.length, 1)
   t.deepEqual(c[type][0], { type, payload: 2 })
+  t.deepEqual(c.all[0], { type, payload: 2 })
 })


### PR DESCRIPTION
Streaming mode is sitting back and watching the stream of events.  Like twitter.

I'm going to make this the default view.

Real-estate is valuable to devs.  We don't need another window demanding full screen status.  I'd like to switch to a tall & narrow viewport.  Streaming mode allows for this.

I still have to solve how state watches will work... but could be an overlay? 


![image](https://cloud.githubusercontent.com/assets/68273/17612463/1b6d15e0-6020-11e6-9b60-adc038509835.png)
