### PR TITLE
Adds support for state.keys.response.

### DIFF
--- a/packages/reactotron-app/App/Commands/StateKeysResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/StateKeysResponseCommand.js
@@ -1,0 +1,123 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Shared/Command'
+import Colors from '../Theme/Colors'
+import { map, isNil, sortBy, toLower } from 'ramda'
+import { inject, observer } from 'mobx-react'
+import AppStyles from '../Theme/AppStyles'
+
+const COMMAND_TITLE = 'STATE KEYS'
+const NULL_MESSAGE = '¯\\_(ツ)_/¯'
+const EMPTY_MESSAGE = 'EMPTY'
+const ROOT_TEXT = '(root)'
+
+const Styles = {
+  path: {
+    padding: '10px 0'
+  },
+  stringValue: {
+    color: Colors.text,
+    WebkitUserSelect: 'all',
+    wordBreak: 'break-all'
+  },
+  null: {
+  },
+  empty: {
+  },
+  keyList: {
+    ...AppStyles.Layout.hbox,
+    flexWrap: 'wrap'
+  },
+  key: {
+    color: Colors.textInverse,
+    backgroundColor: Colors.Palette.matteBlack,
+    padding: '4px 8px',
+    margin: 4,
+    borderRadius: 4
+  }
+}
+
+const sortKeys = sortBy(toLower)
+
+class StateKey extends Component {
+  static propTypes = {
+    stateKey: PropTypes.string.isRequired,
+    onClick: PropTypes.func
+  }
+
+  constructor (props) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+  }
+
+  handleClick = () => {
+    const { onClick, stateKey } = this.props
+    onClick && onClick(stateKey)
+  }
+
+  render () {
+    const { stateKey } = this.props
+    return (
+      <div style={Styles.key} onClick={this.handleClick}>
+        {stateKey}
+      </div>
+    )
+  }
+}
+
+@inject('session')
+@observer
+class StateKeysResponseCommand extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  constructor (props) {
+    super(props)
+    this.renderKey = this.renderKey.bind(this)
+    this.handleKeyClick = this.handleKeyClick.bind(this)
+  }
+
+  shouldComponentUpdate (nextProps) {
+    return this.props.command.id !== nextProps.command.id
+  }
+
+  renderKey (key) {
+    return <StateKey key={`key-${key}`} stateKey={key} onClick={this.handleKeyClick} />
+  }
+
+  handleKeyClick (key) {
+    const { session, command } = this.props
+    const { ui } = session
+    const path = isNil(command.payload.path) ? '' : command.payload.path + '.'
+    ui.getStateValues(`${path}${key}`)
+  }
+
+  renderKeys (keys) {
+    if (isNil(keys)) return <div style={Styles.null}>{NULL_MESSAGE}></div>
+    if (keys.length === 0) return <div style={Styles.empty}>{EMPTY_MESSAGE}></div>
+
+    return (
+      <div style={Styles.keyList}>
+        {map(this.renderKey, sortKeys(keys))}
+      </div>
+    )
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload } = command
+    const { path, keys } = payload
+    const pathText = path || ROOT_TEXT
+
+    return (
+      <Command command={command} title={COMMAND_TITLE} subtitle={pathText}>
+        <div style={Styles.container}>
+          {this.renderKeys(keys)}
+        </div>
+      </Command>
+    )
+  }
+}
+
+export default StateKeysResponseCommand

--- a/packages/reactotron-app/App/Commands/index.js
+++ b/packages/reactotron-app/App/Commands/index.js
@@ -5,6 +5,7 @@ import ApiResponseCommand from './ApiResponseCommand'
 import ClientIntroCommand from './ClientIntroCommand'
 import BenchmarkReportCommand from './BenchmarkReportCommand'
 import StateValuesResponseCommand from './StateValuesResponseCommand'
+import StateKeysResponseCommand from './StateKeysResponseCommand'
 
 export default command => {
   const { type } = command
@@ -16,6 +17,7 @@ export default command => {
     case 'api.response': return ApiResponseCommand
     case 'client.intro': return ClientIntroCommand
     case 'state.values.response': return StateValuesResponseCommand
+    case 'state.keys.response': return StateKeysResponseCommand
     default: return UnknownCommand
   }
 }

--- a/packages/reactotron-app/App/Dialogs/SampleModal.js
+++ b/packages/reactotron-app/App/Dialogs/SampleModal.js
@@ -10,15 +10,19 @@ const ESCAPE_KEYSTROKE = 'Esc'
 const ESCAPE_HINT = 'OMG Cancel'
 const ENTER_KEYSTROKE = 'Enter'
 const ENTER_HINT = 'Search'
-const DIALOG_TITLE = 'State'
-const STATE_INSTRUCTIONS = (<span>Retrieves a value from the state tree at the given path <strong>and all values below</strong>.</span>)
+const TAB_KEYSTROKE = 'Tab'
+const TAB_HINT = 'Keys/Values'
+const DIALOG_TITLE_KEYS = 'State Keys'
+const DIALOG_TITLE_VALUES = 'State Values'
+const STATE_VALUES_INSTRUCTIONS = (<span>Retrieves a value from the state tree at the given path <strong>and all values below</strong>.</span>)
+const STATE_KEYS_INSTRUCTIONS = (<span>Retrieves a list of keys located at the given path in the state tree.</span>)
 const FIELD_LABEL = 'Path'
 
 const Styles = {
   dialog: {
     borderRadius: 4,
     padding: 4,
-    width: 400,
+    width: 450,
     backgroundColor: Colors.screen
   },
   container: {
@@ -111,7 +115,7 @@ class SampleModal extends Component {
     const { path } = this.state
     if (e.key === 'Enter') {
       this.setState({path: null})
-      ui.getStateValues(path)
+      ui.getStateKeysOrValues(path)
       ui.closeStateFindDialog()
     }
   }
@@ -119,6 +123,7 @@ class SampleModal extends Component {
   render () {
     const { ui } = this.props.session
     const open = ui.showStateFindDialog
+    const isKeys = ui.keysOrValues === 'keys'
     if (!open) return null
 
     // need to find a less hacky way of doing this
@@ -129,9 +134,9 @@ class SampleModal extends Component {
           <ModalDialog style={Styles.dialog}>
             <div style={Styles.container}>
               <div style={Styles.header}>
-                <h1 style={Styles.title}>{DIALOG_TITLE}</h1>
+                <h1 style={Styles.title}>{isKeys ? DIALOG_TITLE_KEYS : DIALOG_TITLE_VALUES}</h1>
                 <p style={Styles.subtitle}>
-                  {STATE_INSTRUCTIONS}
+                  {isKeys ? STATE_KEYS_INSTRUCTIONS : STATE_VALUES_INSTRUCTIONS}
                 </p>
               </div>
               <div style={Styles.body}>
@@ -147,10 +152,13 @@ class SampleModal extends Component {
               </div>
               <div style={Styles.keystrokes}>
                 <div style={Styles.hotkey}>
-                  <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span>{ESCAPE_HINT}
+                  <span style={Styles.keystroke}>{ESCAPE_KEYSTROKE}</span> {ESCAPE_HINT}
                 </div>
                 <div style={Styles.hotkey}>
-                  <span style={Styles.keystroke}>{ENTER_KEYSTROKE}</span>{ENTER_HINT}
+                  <span style={Styles.keystroke}>{TAB_KEYSTROKE}</span> {TAB_HINT}
+                </div>
+                <div style={Styles.hotkey}>
+                  <span style={Styles.keystroke}>{ENTER_KEYSTROKE}</span> {ENTER_HINT}
                 </div>
               </div>
             </div>

--- a/packages/reactotron-app/App/Stores/UiStore.js
+++ b/packages/reactotron-app/App/Stores/UiStore.js
@@ -10,19 +10,22 @@ class UI {
    */
   @observable tab = 'streaming'
 
+  /**
+   * Targets state keys or values from the UI & commands.
+   */
+  @observable keysOrValues = 'keys'
+
   // whether or not to show the state find dialog
   @observable showStateFindDialog = false
 
   constructor (server) {
     this.server = server
 
-    Mousetrap.bind('command+1', this.switchTabToStreaming)
-    Mousetrap.bind('command+2', this.switchTabToLogging)
-    Mousetrap.bind('command+3', this.switchTabToState)
-    Mousetrap.bind('command+4', this.switchTabToNetwork)
+    Mousetrap.prototype.stopCallback = () => false
+
     Mousetrap.bind('command+k', this.reset)
     Mousetrap.bind('command+f', this.openStateFindDialog)
-
+    Mousetrap.bind('tab', this.toggleKeysValues)
     Mousetrap.bind('escape', this.popState)
   }
 
@@ -30,22 +33,6 @@ class UI {
     if (this.showStateFindDialog) {
       this.closeStateFindDialog()
     }
-  }
-
-  @action switchTabToStreaming = () => {
-    this.tab = 'streaming'
-  }
-
-  @action switchTabToLogging = () => {
-    this.tab = 'logging'
-  }
-
-  @action switchTabToState = () => {
-    this.tab = 'state'
-  }
-
-  @action switchTabToNetwork = () => {
-    this.tab = 'network'
   }
 
   @action openStateFindDialog = () => {
@@ -60,8 +47,29 @@ class UI {
     this.server.commands.all.clear()
   }
 
+  @action getStateKeysOrValues = (path) => {
+    if (this.keysOrValues === 'keys') {
+      this.getStateKeys(path)
+    } else {
+      this.getStateValues(path)
+    }
+  }
+
   @action getStateValues = (path) => {
     this.server.stateValuesRequest(path)
+  }
+
+  @action getStateKeys = (path) => {
+    this.server.stateKeysRequest(path)
+  }
+
+  @action toggleKeysValues = () => {
+    console.log('toggling opposite of ', this.keysOrValues)
+    if (this.keysOrValues === 'keys') {
+      this.keysOrValues = 'values'
+    } else {
+      this.keysOrValues = 'keys'
+    }
   }
 
 }


### PR DESCRIPTION
Queries as:

![image](https://cloud.githubusercontent.com/assets/68273/17644699/b30a5872-615b-11e6-9623-7ad4859d7ac2.png)


Renders as:

![image](https://cloud.githubusercontent.com/assets/68273/17644698/a18e51fc-615b-11e6-8754-34ec905b8079.png)

Those are also clickable tabs to query for values (as a shortcut).

