### PR TITLE
Adds the display command type; for custom messages.

### DIFF
--- a/packages/demo-react-js/src/App.js
+++ b/packages/demo-react-js/src/App.js
@@ -102,6 +102,10 @@ class App extends Component {
 
         { error ? this.renderError() : this.renderMessage() }
 
+        <div>
+          <button style={Styles.button} onClick={this.props.display}>Custom Messages</button>
+        </div>
+
 
       </div>
     );
@@ -122,8 +126,26 @@ const mapDispatchToProps = dispatch => ({
   requestRedux: () => dispatch(RepoActions.request('reactjs/redux')),
   requestBad: () => dispatch(RepoActions.request('zzzz/zzzzz')),
   handleLogoPress: () => {
-    console.tron.log('wait for it...', true)
+    console.tron.log('wait for it...')
     setTimeout(() => { makeErrorForFun('boom') }, 500)
+  },
+  display: () => {
+    console.tron.display({ name: 'HELLO', value: 'You\'re awesome.', preview: 'Guess what?' })
+    console.tron.display({ name: 'DANGER', value: 9001, important: true, preview: 'It\'s over 9000!' })
+    console.tron.display({ name: 'ORDER', preview: 'Here\'s your order...', value: {
+        app: {
+          color: 'green',
+          vegetable: 'spinach',
+          variant: 'baby',
+          salad: true
+        },
+        main: {
+          type: 'poutine'
+        },
+        when: new Date()
+      }
+    })
+    console.tron.display({ name: 'LIST', value: [1, 'a', true, new Date()], preview: '4 things' })
   }
 })
 

--- a/packages/reactotron-app/App/Commands/ApiResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/ApiResponseCommand.js
@@ -7,6 +7,7 @@ import makeTable from '../Shared/MakeTable'
 import Colors from '../Theme/Colors'
 import AppStyles from '../Theme/AppStyles'
 import SectionLink from './SectionLink'
+import Content from '../Shared/Content'
 
 const COMMAND_TITLE = 'API RESPONSE'
 const REQUEST_HEADER_TITLE = 'Request Headers'
@@ -89,19 +90,6 @@ class ApiResponseCommand extends Component {
     return !(equals(nextProps, this.props) && equals(this.state, nextState))
   }
 
-  renderDataAsObjectTree (data) {
-    return <ObjectTree object={data} level={0} />
-  }
-
-  renderDataAsPreTag (data) {
-    const stringified = JSON.stringify(data, 2, 2)
-    return <pre style={Styles.pre}>{stringified}</pre>
-  }
-
-  renderData (data) {
-    return this.renderDataAsObjectTree(data)
-  }
-
   render () {
     const { command } = this.props
     const { showRequestHeaders, showResponseHeaders, showRequestBody, showResponseBody } = this.state
@@ -134,9 +122,9 @@ class ApiResponseCommand extends Component {
           </div>
 
           <div style={Styles.content}>
-            {showResponseBody && this.renderData(responseBody)}
+            {showResponseBody && <Content value={responseBody} />}
             {showResponseHeaders && makeTable(responseHeaders)}
-            {showRequestBody && (isNilOrEmpty(requestBody) ? NO_REQUEST_BODY : this.renderData(requestBody))}
+            {showRequestBody && (isNilOrEmpty(requestBody) ? NO_REQUEST_BODY : <Content value={requestBody} />)}
             {showRequestHeaders && makeTable(requestHeaders)}
           </div>
 

--- a/packages/reactotron-app/App/Commands/DisplayCommand.js
+++ b/packages/reactotron-app/App/Commands/DisplayCommand.js
@@ -1,0 +1,30 @@
+import React, { Component, PropTypes } from 'react'
+import Command from '../Shared/Command'
+import Content from '../Shared/Content'
+
+const COMMAND_TITLE = 'DISPLAY'
+
+class DisplayCommand extends Component {
+
+  static propTypes = {
+    command: PropTypes.object.isRequired
+  }
+
+  shouldComponentUpdate (nextProps) {
+    return this.props.command.id !== nextProps.command.id
+  }
+
+  render () {
+    const { command } = this.props
+    const { payload, important } = command
+    const { name, value, preview } = payload
+
+    return (
+      <Command command={command} title={name || COMMAND_TITLE} important={important} preview={preview}>
+        <Content value={value} />
+      </Command>
+    )
+  }
+}
+
+export default DisplayCommand

--- a/packages/reactotron-app/App/Commands/LogCommand.js
+++ b/packages/reactotron-app/App/Commands/LogCommand.js
@@ -1,9 +1,9 @@
 import React, { Component, PropTypes } from 'react'
 import Command from '../Shared/Command'
-import ObjectTree from '../Shared/ObjectTree'
-import { take, replace, merge, map, trim, split } from 'ramda'
+import { take, replace, merge, map } from 'ramda'
 import Colors from '../Theme/Colors'
 import AppStyles from '../Theme/AppStyles'
+import Content from '../Shared/Content'
 
 const STACK_TITLE = 'YE OLDE STACK TRACE'
 const PREVIEW_LENGTH = 500
@@ -14,25 +14,6 @@ const getName = level => {
     case 'warn': return 'WARNING'
     case 'error': return 'ERROR'
     default: return 'LOG'
-  }
-}
-let spanCount = 0
-const breakIntoSpans = (part) => {
-  spanCount++
-  return (
-    <span key={`span-${spanCount}`}>{part}<br /></span>
-  )
-}
-
-const formatMessage = message => {
-  if (typeof message === 'string') {
-    return (
-      <div>
-        {map(breakIntoSpans, split('\n', trim(message)))}
-      </div>
-    )
-  } else if (typeof message === 'object') {
-    return <ObjectTree object={{payload: message}} />
   }
 }
 
@@ -138,7 +119,7 @@ class LogCommand extends Component {
     return (
       <Command command={command} title={title} preview={preview}>
         <div style={containerTypes}>
-          {formatMessage(message)}
+          <Content value={message} />
           {stack && this.renderStack(stack)}
         </div>
       </Command>

--- a/packages/reactotron-app/App/Commands/StateActionCompleteCommand.js
+++ b/packages/reactotron-app/App/Commands/StateActionCompleteCommand.js
@@ -1,9 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import Command from '../Shared/Command'
-import ObjectTree from '../Shared/ObjectTree'
 import Colors from '../Theme/Colors'
-import isShallow from '../Lib/IsShallow'
-import makeTable from '../Shared/MakeTable'
+import Content from '../Shared/Content'
 
 const COMMAND_TITLE = 'ACTION'
 
@@ -25,10 +23,6 @@ class StateActionComplete extends Component {
     return this.props.command.id !== nextProps.command.id
   }
 
-  renderContent (action) {
-    return isShallow ? makeTable(action) : <ObjectTree object={{action}} />
-  }
-
   render () {
     const { command } = this.props
     const { payload } = command
@@ -39,7 +33,7 @@ class StateActionComplete extends Component {
       <Command command={command} title={COMMAND_TITLE} duration={ms} preview={preview}>
         <div style={Styles.container}>
           <div style={Styles.name}>{name}</div>
-          {this.renderContent(action)}
+          <Content value={action} />
         </div>
       </Command>
     )

--- a/packages/reactotron-app/App/Commands/StateValuesChangeCommand.js
+++ b/packages/reactotron-app/App/Commands/StateValuesChangeCommand.js
@@ -1,9 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import Command from '../Shared/Command'
-import ObjectTree from '../Shared/ObjectTree'
 import Colors from '../Theme/Colors'
-import isShallow from '../Lib/IsShallow'
-import makeTable from '../Shared/MakeTable'
+import Content from '../Shared/Content'
 import { keys, concat, join } from 'ramda'
 import { mapKeys, isNilOrEmpty } from 'ramdasauce'
 
@@ -25,10 +23,6 @@ class StateValuesChangeCommand extends Component {
 
   shouldComponentUpdate (nextProps) {
     return this.props.command.id !== nextProps.command.id
-  }
-
-  renderContent (action) {
-    return isShallow ? makeTable(action) : <ObjectTree object={{action}} />
   }
 
   render () {
@@ -55,9 +49,9 @@ class StateValuesChangeCommand extends Component {
     return (
       <Command command={command} title={COMMAND_TITLE} preview={preview}>
         <div style={Styles.container}>
-          {hasChanged && this.renderContent(changed)}
-          {hasAdded && this.renderContent(added)}
-          {hasRemoved && this.renderContent(removed)}
+          {hasChanged && <Content value={changed} />}
+          {hasAdded && <Content value={added} />}
+          {hasRemoved && <Content value={removed} />}
         </div>
       </Command>
     )

--- a/packages/reactotron-app/App/Commands/StateValuesResponseCommand.js
+++ b/packages/reactotron-app/App/Commands/StateValuesResponseCommand.js
@@ -1,15 +1,10 @@
 import React, { Component, PropTypes } from 'react'
 import Command from '../Shared/Command'
-import ObjectTree from '../Shared/ObjectTree'
 import Colors from '../Theme/Colors'
-import { isNil } from 'ramda'
-import makeTable from '../Shared/MakeTable'
-import isShallow from '../Lib/IsShallow'
+import Content from '../Shared/Content'
 
-const NULL_TEXT = '¯\\_(ツ)_/¯'
 const ROOT_TEXT = '(root)'
 const COMMAND_TITLE = 'STATE'
-const UNKNOWN_MESSAGE = 'Not sure how to render this value'
 const PATH_LABEL = ''
 
 const Styles = {
@@ -36,43 +31,6 @@ class StateValuesResponseCommand extends Component {
     return this.props.command.id !== nextProps.command.id
   }
 
-  renderObject (value) {
-    return <ObjectTree object={value} level={0} />
-  }
-
-  renderString (value) {
-    return <div style={Styles.stringValue}>{value}</div>
-  }
-
-  renderTable (value) {
-    return makeTable(value)
-  }
-
-  renderNull () {
-    return NULL_TEXT
-  }
-
-  renderValue (value) {
-    if (isNil(value)) {
-      return this.renderNull()
-    }
-    switch (typeof value) {
-      case 'object':
-        if (isShallow(value)) {
-          return this.renderTable(value)
-        } else {
-          return this.renderObject(value)
-        }
-
-      case 'string':
-      case 'number':
-        return this.renderString(value)
-
-      default:
-        return <div style={Styles.unknown}>{UNKNOWN_MESSAGE}</div>
-    }
-  }
-
   render () {
     const { command } = this.props
     const { payload } = command
@@ -83,7 +41,7 @@ class StateValuesResponseCommand extends Component {
       <Command command={command} title={COMMAND_TITLE} startsOpen>
         <div style={Styles.container}>
           <div style={Styles.path}><span style={Styles.pathLabel}>{PATH_LABEL}</span> {pathText}</div>
-          {this.renderValue(value)}
+          <Content value={value} />
         </div>
       </Command>
     )

--- a/packages/reactotron-app/App/Commands/index.js
+++ b/packages/reactotron-app/App/Commands/index.js
@@ -7,6 +7,7 @@ import BenchmarkReportCommand from './BenchmarkReportCommand'
 import StateValuesResponseCommand from './StateValuesResponseCommand'
 import StateKeysResponseCommand from './StateKeysResponseCommand'
 import StateValuesChangeCommand from './StateValuesChangeCommand'
+import DisplayCommand from './DisplayCommand'
 
 export default command => {
   const { type } = command
@@ -20,6 +21,7 @@ export default command => {
     case 'state.values.response': return StateValuesResponseCommand
     case 'state.keys.response': return StateKeysResponseCommand
     case 'state.values.change': return StateValuesChangeCommand
+    case 'display': return DisplayCommand
     default: return UnknownCommand
   }
 }

--- a/packages/reactotron-app/App/Shared/Command.js
+++ b/packages/reactotron-app/App/Shared/Command.js
@@ -3,9 +3,9 @@ import Colors from '../Theme/Colors'
 import AppStyles from '../Theme/AppStyles'
 import Timestamp from '../Shared/Timestamp'
 import { observer } from 'mobx-react'
-import { isNilOrEmpty } from 'ramdasauce'
 import { merge, equals } from 'ramda'
 import CommandToolbar from './CommandToolbar'
+import DisplayIcon from 'react-icons/lib/md/label'
 
 const IconOpen = require('react-icons/lib/md/expand-more')
 const IconClosed = require('react-icons/lib/md/chevron-right')
@@ -47,6 +47,11 @@ const Styles = {
     borderRadius: 4,
     padding: '4px 8px'
   },
+  displayIcon: {
+    marginRight: 4,
+    marginBottom: 4
+  },
+  displayIconSize: 16,
   preview: {
     color: Colors.highlight,
     textAlign: 'left',
@@ -111,7 +116,8 @@ class Command extends Component {
   render () {
     const { isOpen } = this.state
     const { command, children, title, preview } = this.props
-    const { important } = command
+    const { important, type } = command
+    const isDisplay = type === 'display'
     const { date } = command
     const titleTextStyle = merge(Styles.titleText, important ? Styles.titleTextInverse : {})
     const topRowStyle = Styles.topRow
@@ -124,7 +130,10 @@ class Command extends Component {
           <div style={topRowStyle} onClick={this.handleToggleOpen}>
             <Timestamp date={date} style={timestampStyle} />
             <div style={Styles.title}>
-              <span style={titleTextStyle}>{title}</span>
+              <span style={titleTextStyle}>
+                {isDisplay && <DisplayIcon size={Styles.displayIconSize} style={Styles.displayIcon} />}
+                {title}
+              </span>
             </div>
             {!isOpen && <span style={Styles.preview}>{preview}</span>}
             {isOpen && <CommandToolbar command={command} />}

--- a/packages/reactotron-app/App/Shared/Content.js
+++ b/packages/reactotron-app/App/Shared/Content.js
@@ -1,0 +1,69 @@
+import React, { Component, PropTypes } from 'react'
+import { map, trim, split, isNil } from 'ramda'
+import ObjectTree from './ObjectTree'
+import isShallow from '../Lib/IsShallow'
+import makeTable from './MakeTable'
+
+const NULL_TEXT = '¯\\_(ツ)_/¯'
+
+class Content extends Component {
+
+  static propTypes = {
+    value: PropTypes.oneOfType([ PropTypes.object, PropTypes.array, PropTypes.string, PropTypes.number, PropTypes.bool ]),
+    treeLevel: PropTypes.number
+  }
+
+  constructor (props) {
+    super(props)
+    this.spanCount = 0
+    this.breakIntoSpans = this.breakIntoSpans.bind(this)
+  }
+
+  breakIntoSpans (part) {
+    this.spanCount++
+    return (
+      <span key={`span-${this.spanCount}`}>{part}<br /></span>
+    )
+  }
+
+  renderString () {
+    const { value } = this.props
+    return (
+      <div>
+        {map(this.breakIntoSpans, split('\n', trim(value)))}
+      </div>
+    )
+  }
+
+  // render as object with shallow objects rendered as tables
+  renderObject () {
+    const { treeLevel = 0, value } = this.props
+    return isShallow(value) ? makeTable(value) : <ObjectTree object={value} level={treeLevel} />
+  }
+
+  // arrays just render as objects at this point
+  renderArray () {
+    this.renderObject()
+  }
+
+  renderMysteryMeat () {
+    const { value } = this.props
+    return (
+      <div>{String(value)}</div>
+    )
+  }
+
+  render () {
+    const { value } = this.props
+    if (isNil(value)) return <div>{NULL_TEXT}</div>
+    const valueType = typeof value
+    switch (valueType) {
+      case 'string': return this.renderString()
+      case 'object': return this.renderObject()
+      case 'array': return this.renderArray()
+      default: return this.renderMysteryMeat()
+    }
+  }
+}
+
+export default Content

--- a/packages/reactotron-app/main.development.js
+++ b/packages/reactotron-app/main.development.js
@@ -15,7 +15,7 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   mainWindow = new BrowserWindow({
     show: false,
-    width: 550,
+    width: 650,
     height: 800,
     useContentHeight: true,
     titleBarStyle: 'hidden'

--- a/packages/reactotron-core-client/README.md
+++ b/packages/reactotron-core-client/README.md
@@ -155,6 +155,15 @@ const elapsed = client.startTimer()
 // do something you want to time
 const ms = elapsed()  // the number of ms it took.  ish.
 
+// display a custom event
+client.display({
+  name: 'MY EVENT',
+  value: { color: 'green', vegetable: 'spinach', variant: 'baby', salad: true },
+  important: true,
+  preview: 'What\'s in my appetizer?'
+})
+
+
 ```
 
 # Why are we passing socket.io down?
@@ -395,6 +404,23 @@ Sent from the client to server when it's time to report some performance details
     { "title": "lookup tables", "time": 123 },
     { "title": "randomize", "time": 422 }
   ]
+}
+```
+
+### display
+
+Sent from the client to the server to provide a way to show "custom" commands.
+```json
+{
+  "name": "MY EVENT",
+  "value": {
+    "color": "green",
+    "vegetable": "spinach",
+    "variant": "baby",
+    "salad": true
+  },
+  "important": true,
+  "preview": "What's in my appetizer?"
 }
 ```
 

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -124,6 +124,13 @@ export class Client {
   }
 
   /**
+   * Sends a custom command to the server to displays nicely.
+   */
+  display ({ name, value, preview, important = false }) {
+    this.send('display', { name, value, preview }, important)
+  }
+
+  /**
    * Adds a plugin to the system
    */
   use (pluginCreator) {

--- a/packages/reactotron-core-server/src/types.js
+++ b/packages/reactotron-core-server/src/types.js
@@ -7,5 +7,6 @@ export default [
   'state.keys.response',
   'state.values.change',
   'api.response',
-  'benchmark.report'
+  'benchmark.report',
+  'display'
 ]


### PR DESCRIPTION
You can now display your own messages.  It's like `log` but with a few more bells & whistles.

```js
Reactotron.display({ name: 'HELLO', value: 'how are you?', preview: '...' })
```

They show up with a label icon and whatever name you pass.

![image](https://cloud.githubusercontent.com/assets/68273/17838011/0c5b4bf4-6790-11e6-8e04-e1460b140557.png)
