### PR TITLE
Update installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,16 +4,27 @@
 
 A CLI and OS X app for inspecting your [React JS](https://facebook.github.io/react/) and [React Native](https://facebook.github.io/react-native/) apps.
 
-# Download
+# Installing
 
-[Download OS X App](https://github.com/reactotron/reactotron/releases/download/v1.0.0/Reactotron.app.zip) from Github...
-
-Or Install CLI with:
+## Install CLI with NPM
 
 ```
 npm install -g reactotron-cli
 ```
 
+## Install OS X application 
+
+[Download OS X App](https://github.com/reactotron/reactotron/releases/download/v1.0.0/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
+
+### Using Homebrew
+
+Reactotron is also available via [Homebrew Cask](https://caskroom.github.io/) package manager. To ensure you get the latest version, update Homebrew first:
+
+`brew update`
+
+Then simply type:
+
+`brew cask install reactotron`
 
 # About
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A CLI and OS X app for inspecting your [React JS](https://facebook.github.io/rea
 
 ## Install CLI with NPM
 
-```
+```sh
 npm install -g reactotron-cli
 ```
 
@@ -20,11 +20,15 @@ npm install -g reactotron-cli
 
 Reactotron is also available via [Homebrew Cask](https://caskroom.github.io/) package manager. To ensure you get the latest version, update Homebrew first:
 
-`brew update`
+```sh
+brew update
+```
 
 Then simply type:
 
-`brew cask install reactotron`
+```
+brew cask install reactotron
+```
 
 # About
 


### PR DESCRIPTION
Reorganized download/installation section, added instruction on installing via Homebrew.

Should be merged after https://github.com/caskroom/homebrew-cask/pull/24012 is accepted and merged.