### PR TITLE
reactotron-app: fix case sensitive file paths

### DIFF
--- a/packages/reactotron-app/App/index.js
+++ b/packages/reactotron-app/App/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from 'react-dom'
 import App from './Foundation/App'
-import './App.global.css'
+import './app.global.css'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 injectTapEventPlugin()
 

--- a/packages/reactotron-app/main.development.js
+++ b/packages/reactotron-app/main.development.js
@@ -30,7 +30,7 @@ app.on('ready', () => {
     menuItem.checked = nextValue
   }
 
-  mainWindow.loadURL(`file://${__dirname}/App/App.html`)
+  mainWindow.loadURL(`file://${__dirname}/App/app.html`)
 
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow.show()

--- a/packages/reactotron-app/webpack.config.development.js
+++ b/packages/reactotron-app/webpack.config.development.js
@@ -10,7 +10,7 @@ const config = {
 
   entry: [
     'webpack-hot-middleware/client?path=http://localhost:3001/__webpack_hmr',
-    './App/Index'
+    './App/index'
   ],
 
   output: {

--- a/packages/reactotron-app/webpack.config.production.js
+++ b/packages/reactotron-app/webpack.config.production.js
@@ -7,7 +7,7 @@ const config = {
 
   devtool: 'source-map',
 
-  entry: './App/Index',
+  entry: './App/index',
 
   output: {
     ...baseConfig.output,


### PR DESCRIPTION
This fixes the incorrect case in a few file paths that prevented
electron/webpack from loading files on case sensitive file systems (ie,
those on Unix systems).