### PR TITLE
Fix typo in `reactotron-apisauce` README

### DIFF
--- a/packages/reactotron-apisauce/README.md
+++ b/packages/reactotron-apisauce/README.md
@@ -20,7 +20,7 @@ import tronsauce from 'reactotron-apisauce'
 
 Reactotron
   .configure()
-  .use(tronsauce) // <-- here we go!!!
+  .use(tronsauce()) // <-- here we go!!!
   .connect()
 
 // meanwhile, in a different file, when you get a response back


### PR DESCRIPTION
After following the directions in the `reactotron-apisauce` README, I noticed API calls were not being logged. The README says to use `Reactotron.use(tronsauce)` while the demo app uses `Reactotron.use(tronsauce())`. After changing to calling `tronsauce` the calls started showing up in Reactotron.