### PR TITLE
Ensures transient deps are installed.

### DIFF
--- a/packages/reactotron-react-js/package.json
+++ b/packages/reactotron-react-js/package.json
@@ -58,7 +58,10 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "stacktrace-js": "^1.3.1",
+    "ramda": "^0.22.1",
+    "ramdasauce": "^1.1.0",
     "socket.io": "^1.4.8",
+    "socket.io-client": "^1.4.8",
     "reactotron-core-client": "^1.0.0"
   }
 }

--- a/packages/reactotron-react-native/package.json
+++ b/packages/reactotron-react-native/package.json
@@ -65,6 +65,7 @@
     "ramda": "^0.22.1",
     "ramdasauce": "^1.1.0",
     "socket.io": "^1.4.8",
+    "socket.io-client": "^1.4.8",
     "reactotron-core-client": "^1.0.0"
   }
 }


### PR DESCRIPTION
Following the advice of @vjpr in #48.  This does indeed make things work on npm 2.  Also, curious side effect.  Holy balls!  NPM 2 is amazingly fast compared to NPM 3.  Like night & day.  