### PR TITLE
Switches the demo-react-js app to dev dependency only.

### DIFF
--- a/packages/demo-react-js/README.md
+++ b/packages/demo-react-js/README.md
@@ -1,4 +1,19 @@
-## Reactotron Notes
+# Reactotron Notes
+
+## Using in dev mode only
+
+I've altered this example to show a few techniques you can use in order to keep Reactotron living as a dev dependency.
+
+You'll notice that we don't `import`, we `require` because you can conditionally `import` in ES6.
+
+In the other places around the app, you'll see Reactotron guarded by `if (process.env.NODE_ENV !== 'production')`.  With a webpack build, in production mode, this will get stripped out.  Which is great, except for `require` statements.  So, in that case, you'll see a guard style.
+
+All of these "extras" amount to really ugly code.  I only use Reactotron while I'm building/troubleshooting.  Once I get to the bottom of things, I tend to remove the `Reactotron` or `console.tron` statements.  Because of this, I typically just type `console.tron.log()`, and when I'm done, delete it.
+
+It's your call how you debug your app.  If you want to just use Reactotron as a normal dependency `--save` intead, do it.  Just make sure you don't run `Reactotron.connect()` in production builds.  :)
+
+
+## Source Maps Issue
 
 With `create-react-app`, the default devtool is `eval`.  We need that set to `source-map` to
 get the stack traces proper.
@@ -15,6 +30,6 @@ Change the line that currently says
 
 to
 
-`devtool: 'source-map',`
+`devtool: 'source-maps',`
 
 It's the first line after the module exports.  (line 18, but that will change as new version get put out)

--- a/packages/demo-react-js/src/App.js
+++ b/packages/demo-react-js/src/App.js
@@ -37,10 +37,6 @@ class App extends Component {
     fetching: PropTypes.bool
   }
 
-  componentWillMount () {
-    // this.props.startup()
-  }
-
   renderError () {
     const { error } = this.props
     return (
@@ -126,13 +122,13 @@ const mapDispatchToProps = dispatch => ({
   requestRedux: () => dispatch(RepoActions.request('reactjs/redux')),
   requestBad: () => dispatch(RepoActions.request('zzzz/zzzzz')),
   handleLogoPress: () => {
-    console.tron.log('wait for it...')
+    if (console.tron) console.tron.log('wait for it...')
     setTimeout(() => { makeErrorForFun('boom') }, 500)
   },
   display: () => {
-    console.tron.display({ name: 'HELLO', value: 'You\'re awesome.', preview: 'Guess what?' })
-    console.tron.display({ name: 'DANGER', value: 9001, important: true, preview: 'It\'s over 9000!' })
-    console.tron.display({ name: 'ORDER', preview: 'Here\'s your order...', value: {
+    if (console.tron) console.tron.display({ name: 'HELLO', value: 'You\'re awesome.', preview: 'Guess what?' })
+    if (console.tron) console.tron.display({ name: 'DANGER', value: 9001, important: true, preview: 'It\'s over 9000!' })
+    if (console.tron) console.tron.display({ name: 'ORDER', preview: 'Here\'s your order...', value: {
         app: {
           color: 'green',
           vegetable: 'spinach',
@@ -145,7 +141,7 @@ const mapDispatchToProps = dispatch => ({
         when: new Date()
       }
     })
-    console.tron.display({ name: 'LIST', value: [1, 'a', true, new Date()], preview: '4 things' })
+    if (console.tron) console.tron.display({ name: 'LIST', value: [1, 'a', true, new Date()], preview: '4 things' })
   }
 })
 

--- a/packages/demo-react-js/src/ReactotronConfig.js
+++ b/packages/demo-react-js/src/ReactotronConfig.js
@@ -1,10 +1,13 @@
-import Reactotron, { trackGlobalErrors } from 'reactotron-react-js'
-import tronsauce from 'reactotron-apisauce'
+if (process.env.NODE_ENV !== 'production') {
+  const Reactotron = require('reactotron-react-js').default
+  const { trackGlobalErrors } = require('reactotron-react-js')
+  const tronsauce = require('reactotron-apisauce')
 
-Reactotron
-  .configure({ name: 'Demo Time!', secure: false })
-  .use(tronsauce())
-  .use(trackGlobalErrors({ offline: false }))
-  .connect()
+  Reactotron
+    .configure({ name: 'Demo Time!', secure: false })
+    .use(tronsauce())
+    .use(trackGlobalErrors({ offline: false }))
+    .connect()
 
-console.tron = Reactotron
+  console.tron = Reactotron
+}

--- a/packages/demo-react-js/src/Sagas/index.js
+++ b/packages/demo-react-js/src/Sagas/index.js
@@ -1,6 +1,6 @@
 import { takeEvery, takeLatest } from 'redux-saga'
 import ApiSauce from 'apisauce'
-import Reactotron from 'reactotron-react-js'
+const Reactotron = process.env.NODE_ENV !== 'production' && require('reactotron-react-js').default
 
 import * as Startup from '../Redux/Startup.redux'
 import * as Repo from '../Redux/Repo.redux'
@@ -15,7 +15,9 @@ const api = ApiSauce.create({
   }
 })
 
-api.addMonitor(Reactotron.apisauce)
+if (process.env.NODE_ENV !== 'production') {
+  api.addMonitor(Reactotron.apisauce)
+}
 
 export default function * rootSaga () {
   yield [

--- a/packages/demo-react-native/App/Containers/RootContainer.js
+++ b/packages/demo-react-native/App/Containers/RootContainer.js
@@ -11,7 +11,7 @@ import { Actions as LogoActions } from '../Redux/LogoRedux'
 import makeErrorForFun from '../Lib/ErrorMaker'
 import { keys, map, join } from 'ramda'
 
-export default class RootContainer extends Component {
+export class RootContainer extends Component {
 
   constructor (props) {
     super(props)


### PR DESCRIPTION
There was some questions about using Reactotron in `--save-dev` vs. `--save`.  

My advice was to run in `--save-dev` only, but as seen in #173, I didn't quite follow through with "why" OR "how"?  In fact, as @lukesneeringer points out.  My advice leads to a broken build.

I've recently written about [why](https://github.com/reactotron/reactotron/blob/master/docs/tips.md), but this PR shows how.

Again, nothing is stopping you from running `--save`, just please don't run `Reactotron.connect()` in production builds.

Thanks!  Sorry for the confusion.