### PR TITLE
Image support

### DIFF
--- a/packages/demo-react-native/App/Containers/RootContainer.js
+++ b/packages/demo-react-native/App/Containers/RootContainer.js
@@ -12,7 +12,7 @@ import makeErrorForFun from '../Lib/ErrorMaker'
 import { keys, map, join } from 'ramda'
 import RNViewShot from 'react-native-view-shot'
 
-export class RootContainer extends Component {
+class RootContainer extends Component {
 
   constructor (props) {
     super(props)
@@ -21,17 +21,29 @@ export class RootContainer extends Component {
     this.handlePressWarn = () => console.tron.warn('This is a warn message')
     this.handlePressError = () => console.tron.error('This is a error message')
     this.handleScreenshot = this.handleScreenshot.bind(this)
+    this.handleSendCatPicture = this.handleSendCatPicture.bind(this)
   }
 
   handlePress () {
     console.tron.log('A touchable was pressed.🔥🦄')
   }
 
+  handleSendCatPicture () {
+    console.tron.image({
+      uri: 'https://placekitten.com/g/400/400',
+      preview: 'placekitten.com',
+      filename: 'cat.jpg',
+      width: 400,
+      height: 400,
+      caption: 'D\'awwwwwww'
+    })
+  }
+
   handleScreenshot () {
     RNViewShot
-      .takeSnapshot(this.refs.foo, { base64: true })
+      .takeSnapshot(this.refs.foo, { result: 'data-uri' })
       .then(
-        data => console.tron.display({ name: 'Screenshot', preview: 'A Screenshot', image: { data } }),
+        uri => console.tron.display({ name: 'Screenshot', preview: 'App screenshot', image: { uri } }),
         error => console.tron.error('Oops, snapshot failed', error)
       )
 
@@ -60,8 +72,11 @@ export class RootContainer extends Component {
             bigger={bigger} smaller={smaller} faster={faster} slower={slower}
             reset={reset}
           />
-          <Button text='Error Tyme!' onPress={this.props.bomb} />
-          <Button text='Screenshot' onPress={this.handleScreenshot} />
+          <View style={Styles.buttons}>
+            <Button text='Error Tyme!' onPress={this.props.bomb} />
+            <Button text='Screenshot' onPress={this.handleScreenshot} />
+            <Button text='Cats!' onPress={this.handleSendCatPicture} />
+          </View>
         </View>
       </ScrollView>
     )

--- a/packages/demo-react-native/App/Containers/RootContainer.js
+++ b/packages/demo-react-native/App/Containers/RootContainer.js
@@ -10,6 +10,7 @@ import { Actions as RepoActions } from '../Redux/RepoRedux'
 import { Actions as LogoActions } from '../Redux/LogoRedux'
 import makeErrorForFun from '../Lib/ErrorMaker'
 import { keys, map, join } from 'ramda'
+import RNViewShot from 'react-native-view-shot'
 
 export class RootContainer extends Component {
 
@@ -19,11 +20,21 @@ export class RootContainer extends Component {
     this.handlePressDebug = () => console.tron.debug('This is a debug message')
     this.handlePressWarn = () => console.tron.warn('This is a warn message')
     this.handlePressError = () => console.tron.error('This is a error message')
-
+    this.handleScreenshot = this.handleScreenshot.bind(this)
   }
 
   handlePress () {
     console.tron.log('A touchable was pressed.🔥🦄')
+  }
+
+  handleScreenshot () {
+    RNViewShot
+      .takeSnapshot(this.refs.foo, { base64: true })
+      .then(
+        data => console.tron.display({ name: 'Screenshot', preview: 'A Screenshot', image: { data } }),
+        error => console.tron.error('Oops, snapshot failed', error)
+      )
+
   }
 
   render () {
@@ -31,7 +42,7 @@ export class RootContainer extends Component {
     const { reset, faster, slower, bigger, smaller } = this.props
 
     return (
-      <ScrollView style={Styles.container} contentContainerStyle={Styles.content}>
+      <ScrollView style={Styles.container} contentContainerStyle={Styles.content} ref='foo'>
         <View style={Styles.titleContainer}>
           <Text style={Styles.title}>Awesome Github Viewer!</Text>
           <Text style={Styles.subtitle}>Reactotron Demo</Text>
@@ -50,6 +61,7 @@ export class RootContainer extends Component {
             reset={reset}
           />
           <Button text='Error Tyme!' onPress={this.props.bomb} />
+          <Button text='Screenshot' onPress={this.handleScreenshot} />
         </View>
       </ScrollView>
     )

--- a/packages/demo-react-native/android/app/build.gradle
+++ b/packages/demo-react-native/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-view-shot')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/packages/demo-react-native/android/app/src/main/java/com/demoreactnative/MainApplication.java
+++ b/packages/demo-react-native/android/app/src/main/java/com/demoreactnative/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import fr.greweb.reactnativeviewshot.RNViewShotPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -23,7 +24,8 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
-          new MainReactPackage()
+          new MainReactPackage(),
+          new RNViewShotPackage()
       );
     }
   };

--- a/packages/demo-react-native/android/app/src/main/res/values/strings.xml
+++ b/packages/demo-react-native/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
+
     <string name="app_name">DemoReactNative</string>
 </resources>

--- a/packages/demo-react-native/android/settings.gradle
+++ b/packages/demo-react-native/android/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'DemoReactNative'
 
 include ':app'
+include ':react-native-view-shot'
+project(':react-native-view-shot').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-view-shot/android')

--- a/packages/demo-react-native/ios/DemoReactNative.xcodeproj/project.pbxproj
+++ b/packages/demo-react-native/ios/DemoReactNative.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -23,6 +22,7 @@
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		342ACC778BB242FBBCE58DD4 /* libRNViewShot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8236B1A0819E448B8A2D355B /* libRNViewShot.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +127,8 @@
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = ../node_modules/react-native/React/React.xcodeproj; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = ../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = ../node_modules/react-native/Libraries/Text/RCTText.xcodeproj; sourceTree = "<group>"; };
+		20228C6B7CA7441281136413 /* RNViewShot.xcodeproj */ = {isa = PBXFileReference; name = "RNViewShot.xcodeproj"; path = "../node_modules/react-native-view-shot/ios/RNViewShot.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		8236B1A0819E448B8A2D355B /* libRNViewShot.a */ = {isa = PBXFileReference; name = "libRNViewShot.a"; path = "libRNViewShot.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +154,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				342ACC778BB242FBBCE58DD4 /* libRNViewShot.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -274,6 +277,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
+				20228C6B7CA7441281136413 /* RNViewShot.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -352,7 +356,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 610;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
@@ -586,6 +590,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DemoReactNative.app/DemoReactNative";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 			};
 			name = Debug;
 		};
@@ -599,6 +607,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DemoReactNative.app/DemoReactNative";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 			};
 			name = Release;
 		};
@@ -611,14 +623,15 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = "DemoReactNative/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-        OTHER_LDFLAGS = (
+				OTHER_LDFLAGS = (
 					"$(inherited)",
-          "-ObjC",
-          "-lc++",
-        );
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = DemoReactNative;
 			};
 			name = Debug;
@@ -631,14 +644,15 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = "DemoReactNative/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-        OTHER_LDFLAGS = (
+				OTHER_LDFLAGS = (
 					"$(inherited)",
-          "-ObjC",
-          "-lc++",
-        );
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = DemoReactNative;
 			};
 			name = Release;
@@ -681,6 +695,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -721,6 +736,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/packages/demo-react-native/package.json
+++ b/packages/demo-react-native/package.json
@@ -29,5 +29,8 @@
   ],
   "standard": {
     "parser": "eslint"
+  },
+  "devDependencies": {
+    "react-native-view-shot": "skellock/react-native-view-shot#all"
   }
 }

--- a/packages/demo-react-native/package.json
+++ b/packages/demo-react-native/package.json
@@ -13,6 +13,7 @@
     "ramdasauce": "^1.0.0",
     "react": "15.3.1",
     "react-native": "^0.32.0",
+    "react-native-view-shot": "^1.1.0",
     "react-redux": "^4.4.5",
     "reactotron-apisauce": "^1.0.0",
     "reactotron-core-client": "^1.0.0",
@@ -30,7 +31,5 @@
   "standard": {
     "parser": "eslint"
   },
-  "devDependencies": {
-    "react-native-view-shot": "skellock/react-native-view-shot#all"
-  }
+  "devDependencies": {}
 }

--- a/packages/reactotron-app/App/Commands/DisplayCommand.js
+++ b/packages/reactotron-app/App/Commands/DisplayCommand.js
@@ -4,6 +4,15 @@ import Content from '../Shared/Content'
 
 const COMMAND_TITLE = 'DISPLAY'
 
+const Styles = {
+  imageContainer: {
+  },
+  image: {
+    maxWidth: '100%',
+    maxHeight: '100%'
+  }
+}
+
 class DisplayCommand extends Component {
 
   static propTypes = {
@@ -17,11 +26,16 @@ class DisplayCommand extends Component {
   render () {
     const { command } = this.props
     const { payload, important } = command
-    const { name, value, preview } = payload
+    const { name, value, image, preview } = payload
 
     return (
       <Command command={command} title={name || COMMAND_TITLE} important={important} preview={preview}>
-        <Content value={value} />
+        {value && <Content value={value} />}
+        {image &&
+          <div style={Styles.imageContainer}>
+            <img style={Styles.image} src={`data:image/png;base64,${image.data}`} />
+          </div>
+        }
       </Command>
     )
   }

--- a/packages/reactotron-app/App/Commands/ImageCommand.js
+++ b/packages/reactotron-app/App/Commands/ImageCommand.js
@@ -1,8 +1,9 @@
 import React, { Component, PropTypes } from 'react'
 import Command from '../Shared/Command'
 import Content from '../Shared/Content'
+import Colors from '../Theme/Colors'
 
-const COMMAND_TITLE = 'DISPLAY'
+const COMMAND_TITLE = 'IMAGE'
 
 const Styles = {
   imageContainer: {
@@ -10,6 +11,17 @@ const Styles = {
   image: {
     maxWidth: '100%',
     maxHeight: '100%'
+  },
+  caption: {
+    paddingTop: 10,
+    paddingBottom: 10,
+    fontSize: 'larger'
+  },
+  dimensions: {
+    color: Colors.constant
+  },
+  filename: {
+    color: Colors.highlight
   }
 }
 
@@ -26,16 +38,18 @@ class DisplayCommand extends Component {
   render () {
     const { command } = this.props
     const { payload, important } = command
-    const { name, value, image, preview } = payload
+
+    const { uri, preview, caption, width, height, filename } = payload
+    const dimensions = width && height && `${width} x ${height}`
 
     return (
       <Command command={command} title={name || COMMAND_TITLE} important={important} preview={preview}>
-        {value && <Content value={value} />}
-        {image &&
-          <div style={Styles.imageContainer}>
-            <img style={Styles.image} src={image.uri} />
-          </div>
-        }
+        <div style={Styles.imageContainer}>
+          <img style={Styles.image} src={uri} />
+          {caption && <div style={Styles.caption}>{caption}</div>}
+          {dimensions && <div style={Styles.dimensions}>{dimensions}</div>}
+          {filename && <div style={Styles.filename}>{filename}</div>}
+        </div>
       </Command>
     )
   }

--- a/packages/reactotron-app/App/Commands/index.js
+++ b/packages/reactotron-app/App/Commands/index.js
@@ -8,6 +8,7 @@ import StateValuesResponseCommand from './StateValuesResponseCommand'
 import StateKeysResponseCommand from './StateKeysResponseCommand'
 import StateValuesChangeCommand from './StateValuesChangeCommand'
 import DisplayCommand from './DisplayCommand'
+import ImageCommand from './ImageCommand'
 
 export default command => {
   const { type } = command
@@ -22,6 +23,7 @@ export default command => {
     case 'state.keys.response': return StateKeysResponseCommand
     case 'state.values.change': return StateValuesChangeCommand
     case 'display': return DisplayCommand
+    case 'image': return ImageCommand
     default: return UnknownCommand
   }
 }

--- a/packages/reactotron-core-client/README.md
+++ b/packages/reactotron-core-client/README.md
@@ -258,6 +258,22 @@ and I need to research what these will look like.
 
 Also, how is source maps going to factor in?
 
+### image
+
+Send from the client to the server to pass an image.  The uri field is required
+and is a `data-uri`.  This means, an ordinary http link will work, but as will embedding the image inline.
+
+```json
+{
+  "uri": "http://placekitten.com/g/400/400",
+  "preview": "placekitten.com!",
+  "filename": "cat.jpg",
+  "width": 400,
+  "height": 400,
+  "caption": "D'awwwwwww",
+}
+```
+
 ### state.action.complete
 
 Sent from the client to the server when an action is complete.  It's up to you
@@ -418,6 +434,9 @@ Sent from the client to the server to provide a way to show "custom" commands.
     "vegetable": "spinach",
     "variant": "baby",
     "salad": true
+  },
+  "image": {
+    "uri": "http://placekitten.com/g/400/400"
   },
   "important": true,
   "preview": "What's in my appetizer?"

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -126,8 +126,8 @@ export class Client {
   /**
    * Sends a custom command to the server to displays nicely.
    */
-  display ({ name, value, preview, important = false }) {
-    this.send('display', { name, value, preview }, important)
+  display ({ name, value, preview, image, important = false }) {
+    this.send('display', { name, value, preview, image }, important)
   }
 
   /**

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -1,6 +1,7 @@
 import R from 'ramda'
 import validate from './validate'
 import logger from './plugins/logger'
+import image from './plugins/image'
 import benchmark from './plugins/benchmark'
 import stateResponses from './plugins/state-responses'
 import apiResponse from './plugins/api-response'
@@ -8,6 +9,7 @@ import { start } from './stopwatch'
 export { start } from './stopwatch'
 
 export const CorePlugins = [
+  image(),
   logger(),
   benchmark(),
   stateResponses(),

--- a/packages/reactotron-core-client/src/plugins/image.js
+++ b/packages/reactotron-core-client/src/plugins/image.js
@@ -1,0 +1,12 @@
+/**
+ * Provides an image.
+ */
+export default () => reactotron => {
+  return {
+    features: {
+      // expanded just to show the specs
+      image: ({ uri, preview, filename, width, height, caption }) =>
+        reactotron.send('image', { uri, preview, filename, width, height, caption })
+    }
+  }
+}

--- a/packages/reactotron-core-client/test/plugin-image-test.js
+++ b/packages/reactotron-core-client/test/plugin-image-test.js
@@ -1,0 +1,31 @@
+import test from 'ava'
+import { createClient, CorePlugins } from '../src'
+import socketClient from 'socket.io-client'
+import plugin from '../src/plugins/image'
+
+test('the image function send the right data', t => {
+  const client = createClient({ io: socketClient })
+  const results = []
+  client.send = (type, payload) => { results.push({type, payload}) }
+  client.use(plugin())
+  t.is(client.plugins.length, CorePlugins.length + 1)
+  t.is(typeof client.image, 'function')
+  client.image({
+    uri: 'a',
+    width: 1,
+    height: 2,
+    filename: 'f',
+    preview: 'p',
+    caption: 'c',
+    zoo: 'lol'
+  })
+  t.is(results.length, 1)
+  t.is(results[0].type, 'image')
+  t.is(results[0].payload.uri, 'a')
+  t.is(results[0].payload.width, 1)
+  t.is(results[0].payload.height, 2)
+  t.is(results[0].payload.filename, 'f')
+  t.is(results[0].payload.preview, 'p')
+  t.is(results[0].payload.caption, 'c')
+  t.is(results[0].payload.zoo, undefined)
+})

--- a/packages/reactotron-core-server/src/types.js
+++ b/packages/reactotron-core-server/src/types.js
@@ -2,6 +2,7 @@
 export default [
   'client.intro',
   'log',
+  'image',
   'state.action.complete',
   'state.values.response',
   'state.keys.response',


### PR DESCRIPTION
Support for images.  Both as a standalone command and built into the generic `display`.

Supports `data-uri` so you can do inline base64'ed images or normal `http` urls.

React Native demo includes `react-native-view-shot` by @gre.  It allows you to take a picture of a react-native `ref`.  Awesome stuff!

![image](https://cloud.githubusercontent.com/assets/68273/18025233/406470be-6bf1-11e6-8ae5-c87bf6f49370.png)
