### PR TITLE
Add `npm install` step to Contributing doc

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,9 +10,10 @@ cd reactotron
 git checkout next
 ```
 
-Run the setup script to install the dependencies & run tests.
+Install `lerna` and run the setup script to install the dependencies & run tests.
 
 ```
+npm install
 npm run welcome
 ```
 


### PR DESCRIPTION
Running `npm run welcome` without first installing `lerna` will result in a number of errors.

I fixed this by running `npm install` before `npm run welcome`, but I'm not sure if the expectation is that `lerna` be installed globally.