### PR TITLE
Pass the current state to onRestore as well

### DIFF
--- a/packages/reactotron-redux/src/reactotron-redux.js
+++ b/packages/reactotron-redux/src/reactotron-redux.js
@@ -66,7 +66,7 @@ export default (pluginConfig = {}) => reactotron => {
         // server is asking to clobber state with this
         case 'state.restore.request': {
           // run our state through our onRestore
-          const state = onRestore(payload.state)
+          const state = onRestore(payload.state, reduxStore.getState())
           reduxStore.dispatch({ type: restoreActionType, state })
           return
         }


### PR DESCRIPTION
I have a need to leave a part of my state tree untouched when restoring the state. Adding the ability to pull from the current state in the onrestore allows for this use case.