### PR TITLE
Fixed inaccurate name of isActionImportant

### DIFF
--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -78,9 +78,9 @@ reactotronRedux({
 })
 ```
 
-#### isImportantAction
+#### isActionImportant
 
-`isImportantAction` is a function which receives and action and returns a boolean.
+`isActionImportant` is a function which receives and action and returns a boolean.
 `true` will be cause the action to show up in the Reactotron app with a highlight.
 
 ```js


### PR DESCRIPTION
Following the docs I noticed that the name isn't consistent. `isActionImportant` is the proper function name.