### PR TITLE
Bump Install link version number to latest version 1.4.0

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,7 +4,7 @@ Reactotron comes in two versions.  A desktop version and a CLI.
 
 ### Via Direct Download
 
-[Download OS X App](https://github.com/reactotron/reactotron/releases/download/v1.1.4/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
+[Download OS X App](https://github.com/reactotron/reactotron/releases/download/v1.4.4/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
 
 ### Via Homebrew
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,7 +4,7 @@ Reactotron comes in two versions.  A desktop version and a CLI.
 
 ### Via Direct Download
 
-[Download OS X App](https://github.com/reactotron/reactotron/releases/download/v1.4.4/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
+[Download OS X App](https://github.com/reactotron/reactotron/releases/download/v1.4.0/Reactotron.app.zip) from GitHub release and drop the Reactotron.app to the Applications folder.
 
 ### Via Homebrew
 


### PR DESCRIPTION
![screen shot 2016-11-11 at 12 59 58 pm](https://cloud.githubusercontent.com/assets/10098988/20226762/01382ae8-a80f-11e6-8efb-d6c61d3f804f.png)

### Bump to v1.4.4
![alt tag](http://i.giphy.com/RJL3l2TKNBckg.gif)