### PR TITLE
Fix typo in saga effects title

### DIFF
--- a/packages/reactotron-app/App/Commands/SagaTaskCompleteCommand.js
+++ b/packages/reactotron-app/App/Commands/SagaTaskCompleteCommand.js
@@ -142,7 +142,7 @@ class SagaTaskCompleteCommand extends Component {
     const { payload } = command
     const { description, triggerType, duration, children } = payload
     const preview = `${triggerType} in ${duration}ms`
-    const effectTitle = `${children.length} Effect${children.length > 0 && 's'}`
+    const effectTitle = `${children.length} Effect${children.length === 1 ? '' : 's'}`
 
     return (
       <Command command={command} title={COMMAND_TITLE} preview={preview}>


### PR DESCRIPTION
Just a quick typo fix -- previously, if there were 0 effects, the title would be rendered as "0 Effectfalse":

![image](https://cloud.githubusercontent.com/assets/1062277/20291692/038dd2a8-aab6-11e6-91a0-5b7b96a4d43b.png)

 Instead, only omit the "s" in "effects" when there is exactly 1 effect.