### PR TITLE
Removes copy hack now that lerna symlinks.

### DIFF
--- a/packages/demo-react-js/package.json
+++ b/packages/demo-react-js/package.json
@@ -28,7 +28,6 @@
     "start": "react-scripts start",
     "build-prod": "react-scripts build",
     "eject": "react-scripts eject",
-    "copy-internal-deps": "./copy-internal-deps.sh",
     "lint": "standard"
   },
   "standard": {


### PR DESCRIPTION
Still can't remove this just yet for React Native as the symlinks still don't quite work right over there.