### PR TITLE
Adds a safeRecursion flag to bypass circular dep objects.

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -96,3 +96,15 @@ console.tron.display({
   image: 'http://placekitten.com/g/400/400'
 })
 ```
+
+### Stack Overflow Error While Logging?
+
+There's an issue with one of the dependencies (socket.io) where trying to `console.tron.log` something that has a 
+circular reference will result in a stack overflow.
+
+So in `@1.5.2`, we implemented a safety check to repair any problems with that.
+
+Problem is, it's slow for extremely large payloads.  You can turn this off in `@1.5.3` by adding `safeRecursion: false`
+into your `configure({})` statement in your `ReactotronConfig.js`.
+
+A longer term fix is on the way.  And I'm looking forward to the day I can delete this section.

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -26,6 +26,7 @@ const DEFAULTS = {
   name: 'reactotron-core-client', // some human-friendly session name
   secure: false, // use wss instead of ws
   plugins: CorePlugins, // needed to make society function
+  safeRecursion: true, // when on, it ensures objects are safe for transport (at the cost of CPU)
   onCommand: cmd => null, // the function called when we receive a command
   onConnect: () => null, // fires when we connect
   onDisconnect: () => null // fires when we disconnect
@@ -132,10 +133,15 @@ export class Client {
     // jet if we don't have a socket
     if (!this.socket) return
 
+    // we may or may not want to introduce a first-line defense against socket.io serialization
+    // issues.
+    // NOTE(steve): right now the function id is trapped inside scrub.  Can we split?
+    const actualPayload = this.options.safeRecursion ? scrub(payload) : payload
+
     // send this command
     this.socket.emit('command', {
       type,
-      payload: scrub(payload),
+      payload: actualPayload,
       important: !!important
     })
   }


### PR DESCRIPTION
I decided to go `opt-out` for now.  I think it's more common for people to have circular reference issues rather than massive 6 MB redux state trees.

I'll try to get a permanent solution in place for the performance issues for next minor version.