### PR TITLE
Rearranges a few things around error handling.

### DIFF
--- a/packages/demo-react-native/App/Components/Button.js
+++ b/packages/demo-react-native/App/Components/Button.js
@@ -1,17 +1,23 @@
 import React, { Component, PropTypes } from 'react'
 import { Text, TouchableOpacity } from 'react-native'
 import Styles from './Styles/ButtonStyles'
+import { merge } from 'ramda'
 
 class Button extends Component {
 
   static propTypes = {
     onPress: PropTypes.func,
-    text: PropTypes.string
+    text: PropTypes.string,
+    style: PropTypes.object
   }
 
   render () {
+    const containerStyle = this.props.style
+      ? merge(Styles.container, this.props.style)
+      : Styles.container
+
     return (
-      <TouchableOpacity onPress={this.props.onPress} style={Styles.container}>
+      <TouchableOpacity onPress={this.props.onPress} style={containerStyle}>
         <Text style={Styles.text}>{this.props.text}</Text>
       </TouchableOpacity>
     )

--- a/packages/demo-react-native/App/Config/ReactotronConfig.js
+++ b/packages/demo-react-native/App/Config/ReactotronConfig.js
@@ -4,9 +4,9 @@ import { reactotronRedux } from 'reactotron-redux'
 import sagaPlugin from 'reactotron-redux-saga'
 import { test } from 'ramda'
 
-console.disableYellowBox = true
+// console.disableYellowBox = true
 
-const vetoTest = test(/(YellowBox|redux-saga|node_modules\/react-native)/)
+const vetoTest = test(/(node_modules\/react\/)/)
 
 if (__DEV__) {
   Reactotron

--- a/packages/demo-react-native/App/Config/ReactotronConfig.js
+++ b/packages/demo-react-native/App/Config/ReactotronConfig.js
@@ -1,5 +1,3 @@
-import parseErrorStack from 'parseErrorStack'
-import symbolicateStackTrace from 'symbolicateStackTrace'
 import Reactotron, { trackGlobalErrors, openInEditor } from 'reactotron-react-native'
 import tronsauce from 'reactotron-apisauce'
 import { reactotronRedux } from 'reactotron-redux'
@@ -12,7 +10,7 @@ const vetoTest = test(/(YellowBox|redux-saga|node_modules\/react-native)/)
 
 if (__DEV__) {
   Reactotron
-    .configure({ name: 'React Native Demo', parseErrorStack, symbolicateStackTrace })
+    .configure({ name: 'React Native Demo' })
     .use(tronsauce())
     .use(reactotronRedux({
       isActionImportant: action => action.type === 'something.important',

--- a/packages/demo-react-native/App/Containers/RootContainer.js
+++ b/packages/demo-react-native/App/Containers/RootContainer.js
@@ -76,14 +76,52 @@ class RootContainer extends Component {
             bigger={bigger} smaller={smaller} faster={faster} slower={slower}
             reset={reset}
           />
+
           <View style={Styles.buttons}>
-            <Button text='Error Tyme!' onPress={this.props.bomb} />
             <Button text='Screenshot' onPress={this.handleScreenshot} />
             <Button text='Cats!' onPress={this.handleSendCatPicture} />
           </View>
+
           <View style={Styles.buttons}>
-            <Button text='Error Saga' onPress={this.props.bombSaga} />
-            <Button text='Error Saga Put' onPress={this.props.bombPut} />
+            <Text style={Styles.errorTitle}>
+              Handles Various Sources of Errors
+            </Text>
+          </View>
+
+          <View style={Styles.buttons}>
+            <Button
+              text='Component Error'
+              onPress={this.props.bomb}
+              style={{ width: 200 }}
+            />
+          </View>
+          <View style={Styles.buttons}>
+            <Button
+              text='Try/Catch Exceptions'
+              onPress={this.props.silentBomb}
+              style={{ width: 200 }}
+            />
+          </View>
+          <View style={Styles.buttons}>
+            <Button
+              text='Saga Error'
+              onPress={this.props.bombSaga}
+              style={{ width: 200 }}
+            />
+          </View>
+          <View style={Styles.buttons}>
+            <Button
+              text='Saga Error in PUT (async)'
+              onPress={this.props.bombPut}
+              style={{ width: 200 }}
+            />
+          </View>
+          <View style={Styles.buttons}>
+            <Button
+              text='Saga Error in PUT (sync)'
+              onPress={this.props.bombPutSync}
+              style={{ width: 200 }}
+            />
           </View>
         </View>
       </ScrollView>
@@ -111,12 +149,21 @@ const mapDispatchToProps = dispatch => ({
   requestReactNative: () => dispatch(RepoActions.request('facebook/react-native')),
   requestMobx: () => dispatch(RepoActions.request('mobxjs/mobx')),
   requestRedux: () => dispatch(RepoActions.request('reactjs/redux')),
+  bombPutSync: () => dispatch(ErrorActions.throwPutError(true)),
+  bombPut: () => dispatch(ErrorActions.throwPutError(false)),
+  silentBomb: () => {
+    // you may have try/catch blocks in your code
+    try {
+      console.foo()
+    } catch (e) {
+      // now you can log those errors
+      console.tron.reportError(e)
+    }
+  },
   bomb: () => {
     console.tron.log('wait for it...')
     setTimeout(() => { makeErrorForFun('Boom goes the error message.') }, 500)
   },
-  bombSaga: () => dispatch(ErrorActions.throwSagaError()),
-  bombPut: () => dispatch(ErrorActions.throwPutError())
+  bombSaga: () => dispatch(ErrorActions.throwSagaError())
 })
-
 export default connect(mapStateToProps, mapDispatchToProps)(RootContainer)

--- a/packages/demo-react-native/App/Containers/Styles/RootContainerStyles.js
+++ b/packages/demo-react-native/App/Containers/Styles/RootContainerStyles.js
@@ -2,7 +2,8 @@ import {StyleSheet} from 'react-native'
 
 export default StyleSheet.create({
   container: {
-    backgroundColor: '#4A90E2'
+    backgroundColor: '#4A90E2',
+    flex: 1
   },
   content: {
   },
@@ -18,6 +19,12 @@ export default StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     color: '#FFD898'
+  },
+  errorTitle: {
+    paddingTop: 30,
+    fontSize: 16,
+    textAlign: 'center',
+    color: 'white'
   },
   subtitle: {
     fontSize: 18,

--- a/packages/demo-react-native/App/Lib/BombSquad.js
+++ b/packages/demo-react-native/App/Lib/BombSquad.js
@@ -1,0 +1,7 @@
+
+export function dismantleBomb (cutTheRedWire) {
+  if (cutTheRedWire) {
+    this.isSparta('👢') // this is madness!
+  }
+}
+

--- a/packages/demo-react-native/App/Redux/ErrorRedux.js
+++ b/packages/demo-react-native/App/Redux/ErrorRedux.js
@@ -6,13 +6,13 @@ export const Types = {
 
 export const Actions = {
   throwSagaError: () => ({ type: Types.Saga }),
-  throwPutError: () => ({ type: Types.Put })
+  throwPutError: (isSync = false) => ({ type: Types.Put, isSync })
 }
 
 export const INITIAL_STATE = { }
 
 const throwAnError = (state) =>
-  ({ ...state, error: speed.test }) // eslint-disable-line 
+  ({ ...state, error: this.doesNotExist() })
 
 // actions ->
 const reducerMap = {

--- a/packages/demo-react-native/App/Sagas/ErrorSagas.js
+++ b/packages/demo-react-native/App/Sagas/ErrorSagas.js
@@ -1,14 +1,17 @@
 import { call, put } from 'redux-saga/effects'
 import * as Error from '../Redux/ErrorRedux'
-
-function aDummyFunction () {
-}
+import { dismantleBomb } from '../Lib/BombSquad'
 
 export function * sagaError () {
-  yield call(aDummyFunction)
-  object.that.doesnt.exist() // eslint-disable-line
+  yield call(dismantleBomb, false)
+  yield call(dismantleBomb, true)
 }
 
-export function * putError () {
-  yield put.sync({ type: Error.Types.PutThrow })
+export function * putError (action) {
+  const { isSync } = action
+  if (isSync) {
+    yield put.sync({ type: Error.Types.PutThrow })
+  } else {
+    yield put({ type: Error.Types.PutThrow })
+  }
 }

--- a/packages/demo-react-native/yarn.lock
+++ b/packages/demo-react-native/yarn.lock
@@ -1100,10 +1100,6 @@ component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
 
-component-emitter@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.0.tgz#ccd113a86388d06482d03de3fc7df98526ba8efe"
-
 component-emitter@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -1316,13 +1312,13 @@ debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@2.2.0, debug@^2.0.0, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
 
-debug@2.3.3:
+debug@2.3.3, debug@^2.0.0, debug@^2.1.0, debug@^2.1.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
   dependencies:
@@ -1587,23 +1583,6 @@ end-of-stream@1.0.0, end-of-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
   dependencies:
     once "~1.3.0"
-
-engine.io-client@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-1.7.2.tgz#12f01d3d9d676908a86339cee067ff799a585c3d"
-  dependencies:
-    component-emitter "1.1.2"
-    component-inherit "0.0.3"
-    debug "2.2.0"
-    engine.io-parser "1.3.1"
-    has-cors "1.1.0"
-    indexof "0.0.1"
-    parsejson "0.0.1"
-    parseqs "0.0.2"
-    parseuri "0.0.4"
-    ws "1.1.1"
-    xmlhttprequest-ssl "1.5.1"
-    yeast "0.1.2"
 
 engine.io-client@1.8.1:
   version "1.8.1"
@@ -3409,33 +3388,15 @@ parse-json@^2.1.0, parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parsejson@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.1.tgz#9b10c6c0d825ab589e685153826de0a3ba278bcc"
-  dependencies:
-    better-assert "~1.0.0"
-
 parsejson@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.3.tgz#ab7e3759f209ece99437973f7d0f1f64ae0e64ab"
   dependencies:
     better-assert "~1.0.0"
 
-parseqs@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.2.tgz#9dfe70b2cddac388bde4f35b1f240fa58adbe6c7"
-  dependencies:
-    better-assert "~1.0.0"
-
 parseqs@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
-  dependencies:
-    better-assert "~1.0.0"
-
-parseuri@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.4.tgz#806582a39887e1ea18dd5e2fe0e01902268e9350"
   dependencies:
     better-assert "~1.0.0"
 
@@ -3750,52 +3711,51 @@ react@15.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
-reactotron-apisauce@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/reactotron-apisauce/-/reactotron-apisauce-1.5.2.tgz#81068482f42a31d9a1e84c24fd1fd809c362bc99"
+reactotron-apisauce@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/reactotron-apisauce/-/reactotron-apisauce-1.5.3.tgz#1a910a0aeaea1cc726e06f1c2e49ed5b56c9e802"
   dependencies:
     apisauce "^0.6.0"
     ramda "^0.22.1"
     ramdasauce "^1.1.1"
-    reactotron-core-client "^1.5.2"
+    reactotron-core-client "^1.5.3"
 
-reactotron-core-client@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/reactotron-core-client/-/reactotron-core-client-1.5.2.tgz#3ee708a8c210f05a8fac7802ef75b4ddeb9b59c9"
+reactotron-core-client@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/reactotron-core-client/-/reactotron-core-client-1.5.3.tgz#4fc251c27dfb62eb64fde06d52c91c6858695f1e"
   dependencies:
     json-stringify-safe "^5.0.1"
     ramda "^0.22.1"
     ramdasauce "^1.1.1"
-    socket.io "^1.4.8"
+    socket.io "^1.7.0"
 
-reactotron-react-native@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/reactotron-react-native/-/reactotron-react-native-1.5.2.tgz#43e7526f706891450e6a19bf27f1ce4a200b7197"
+reactotron-react-native@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/reactotron-react-native/-/reactotron-react-native-1.5.3.tgz#bbefc15473b7305a2f8dfd0db89b6e92292786f9"
   dependencies:
     json-stringify-safe "^5.0.1"
     ramda "^0.22.1"
     ramdasauce "^1.1.1"
-    reactotron-core-client "^1.5.2"
-    socket.io "^1.4.8"
-    socket.io-client "^1.4.8"
+    reactotron-core-client "^1.5.3"
+    socket.io-client "~1.7.1"
 
-reactotron-redux-saga@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/reactotron-redux-saga/-/reactotron-redux-saga-1.5.2.tgz#7547c8c9c9b58ba52d03cfae814c3e0e8c1f60b8"
+reactotron-redux-saga@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/reactotron-redux-saga/-/reactotron-redux-saga-1.5.3.tgz#0939a4f6a5d02ab6cc786fe23c02e8744dff7210"
   dependencies:
     ramda "^0.22.1"
     ramdasauce "^1.1.1"
-    reactotron-core-client "^1.5.2"
+    reactotron-core-client "^1.5.3"
     redux "^3.6.0"
     redux-saga "^0.12.1"
 
-reactotron-redux@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/reactotron-redux/-/reactotron-redux-1.5.2.tgz#1d6beded2080f9fd17acf0e457c7dd94d5f09cd2"
+reactotron-redux@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/reactotron-redux/-/reactotron-redux-1.5.3.tgz#0948ee843da80798de54f62209ac69f630f1a7ca"
   dependencies:
     ramda "^0.22.1"
     ramdasauce "^1.1.1"
-    reactotron-core-client "^1.5.2"
+    reactotron-core-client "^1.5.3"
     redux "^3.6.0"
 
 read-all-stream@^3.0.0:
@@ -4145,39 +4105,7 @@ socket.io-adapter@0.5.0:
     debug "2.3.3"
     socket.io-parser "2.3.1"
 
-socket.io-client@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-1.7.0.tgz#d682bde6a83e2d01dd68b5a3696a88c640c4e897"
-  dependencies:
-    backo2 "1.0.2"
-    component-bind "1.0.0"
-    component-emitter "1.2.1"
-    debug "2.3.3"
-    engine.io-client "1.8.1"
-    has-binary "0.1.7"
-    indexof "0.0.1"
-    object-component "0.0.3"
-    parseuri "0.0.5"
-    socket.io-parser "2.3.1"
-    to-array "0.1.4"
-
-socket.io-client@^1.4.8:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-1.5.1.tgz#0f366eae7de34bc880ebd71106e1ce8143775827"
-  dependencies:
-    backo2 "1.0.2"
-    component-bind "1.0.0"
-    component-emitter "1.2.0"
-    debug "2.2.0"
-    engine.io-client "1.7.2"
-    has-binary "0.1.7"
-    indexof "0.0.1"
-    object-component "0.0.3"
-    parseuri "0.0.4"
-    socket.io-parser "2.3.1"
-    to-array "0.1.4"
-
-socket.io-client@~1.7.1:
+socket.io-client@1.7.1, socket.io-client@~1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-1.7.1.tgz#6c23725edff804f3919c1ce4ebb25e591c6e61d7"
   dependencies:
@@ -4202,16 +4130,16 @@ socket.io-parser@2.3.1:
     isarray "0.0.1"
     json3 "3.3.2"
 
-socket.io@^1.4.8:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-1.7.0.tgz#812790768e9eb43f4842f98606fb63b4dd13e343"
+socket.io@^1.7.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-1.7.1.tgz#a34d763fd22cd975643c2f0c7c5f14ba6da80aaf"
   dependencies:
     debug "2.3.3"
     engine.io "1.8.1"
     has-binary "0.1.7"
     object-assign "4.1.0"
     socket.io-adapter "0.5.0"
-    socket.io-client "1.7.0"
+    socket.io-client "1.7.1"
     socket.io-parser "2.3.1"
 
 source-map-support@^0.4.2:
@@ -4882,10 +4810,6 @@ xmldoc@^0.4.0:
 xmldom@0.1.x:
   version "0.1.22"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.22.tgz#10de4e5e964981f03c8cc72fadc08d14b6c3aa26"
-
-xmlhttprequest-ssl@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz#3b7741fea4a86675976e908d296d4445961faa67"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"

--- a/packages/reactotron-app/App/Commands/LogCommand.js
+++ b/packages/reactotron-app/App/Commands/LogCommand.js
@@ -10,8 +10,8 @@ import ReactTooltip from 'react-tooltip'
 import fs from 'fs'
 
 const PREVIEW_LENGTH = 500
-const SOURCE_LINES_UP = 5
-const SOURCE_LINES_DOWN = 5
+const SOURCE_LINES_UP = 3
+const SOURCE_LINES_DOWN = 3
 const SOURCE_FILE_PATH_COUNT = 3
 
 const getName = level => {
@@ -203,32 +203,33 @@ class LogCommand extends Component {
       if (err) { return }
       if (data && is(String, data)) {
         try {
-          let sourceLines
+          let lines
           let lineCounter = 0
           const lineBreak = /\n/g
           const contents = split(lineBreak, data)
-          // should just load it all?
-          const showWholeFile = contents.length < SOURCE_LINES_UP + SOURCE_LINES_DOWN
-
-          if (showWholeFile) {
-            sourceLines = slice(0, contents.length, contents)
-          } else {
-            const lo = max(0, lineNumber - SOURCE_LINES_UP)
-            const hi = min(contents.length - 1, lineNumber + SOURCE_LINES_UP)
-            sourceLines = slice(lo, hi, contents)
-            lineCounter = lo - 1
-          }
 
           // create a new structure of lines
-          const lines = map(line => {
+          const sourceLines = map(line => {
             lineCounter = lineCounter + 1
+            // i am sorry my tab-based brethern.
             const source = replace(/\t/, '  ', line)
             return {
               isSelected: lineCounter === lineNumber,
               lineNumber: lineCounter,
               source
             }
-          }, sourceLines)
+          }, contents)
+
+          // should just load it all?
+          const showWholeFile = contents.length < SOURCE_LINES_UP + SOURCE_LINES_DOWN
+
+          if (showWholeFile) {
+            lines = sourceLines
+          } else {
+            const lo = max(0, lineNumber - SOURCE_LINES_UP - 1)
+            const hi = min(contents.length - 1, lineNumber + SOURCE_LINES_UP)
+            lines = slice(lo, hi, sourceLines)
+          }
 
           // kick it back to React
           this.setState({ lines, lineNumber, fileName, partialFileName })

--- a/packages/reactotron-core-client/src/index.js
+++ b/packages/reactotron-core-client/src/index.js
@@ -150,6 +150,13 @@ export class Client {
   }
 
   /**
+   * Client libraries can hijack this to report errors.
+   */
+  reportError (error) {
+    this.error(error)
+  }
+
+  /**
    * Adds a plugin to the system
    */
   use (pluginCreator) {
@@ -194,33 +201,6 @@ export class Client {
 
     // chain-friendly
     return this
-  }
-
-  reportError (error) {
-    if (this.options.parseErrorStack && this.options.symbolicateStackTrace) {
-      const parsedStacktrace = this.options.parseErrorStack(error)
-
-      this.options.symbolicateStackTrace(parsedStacktrace).then(symbolcatedStack => {
-        const mappedStack = symbolcatedStack.map(stackFrame => ({
-          fileName: stackFrame.file,
-          functionName: stackFrame.methodName,
-          lineNumber: stackFrame.lineNumber
-        }))
-
-        this.send('log', {
-          level: 'error',
-          message: error.message,
-          stack: mappedStack
-        })
-      })
-
-      return
-    }
-
-    this.send('log', {
-      level: 'error',
-      ...error
-    })
   }
 
 }

--- a/packages/reactotron-react-native/src/plugins/track-global-errors.js
+++ b/packages/reactotron-react-native/src/plugins/track-global-errors.js
@@ -77,13 +77,18 @@ export default options => reactotron => {
         const parsedStacktrace = parseErrorStack(error)
 
         symbolicateStackTrace(parsedStacktrace).then(goodStack => {
-          const mappedStack = goodStack.map(stackFrame => ({
+          let stack = goodStack.map(stackFrame => ({
             fileName: stackFrame.file,
             functionName: stackFrame.methodName,
             lineNumber: stackFrame.lineNumber
           }))
 
-          this.error(error.message, mappedStack)
+          // does the dev want us to keep each frame?
+          if (config.veto) {
+            stack = reject(config.veto, stack)
+          }
+
+          reactotron.error(error.message, stack)
         })
 
         return

--- a/packages/reactotron-redux-saga/src/reactotron-plugin.js
+++ b/packages/reactotron-redux-saga/src/reactotron-plugin.js
@@ -5,7 +5,6 @@ export default pluginConfig => reactotron => ({
   // make these functions available on the Reactotron
   features: {
     // spawn a saga monitor with the given options
-    createSagaMonitor: options => createSagaMonitor(reactotron, options),
-    handleSagaError: error => reactotron.reportError(error)
+    createSagaMonitor: options => createSagaMonitor(reactotron, options)
   }
 })

--- a/packages/reactotron-redux-saga/src/saga-monitor.js
+++ b/packages/reactotron-redux-saga/src/saga-monitor.js
@@ -164,7 +164,9 @@ export default (reactotron, options) => {
         onTaskResult,
         error => {
           effectRejected(effectId, error)
-          if (!error.reactotronWasHere) reactotron.reportError(error)
+          if (!error.reactotronWasHere) {
+            reactotron.reportError(error)
+          }
           error.reactotronWasHere = true
         }
       )


### PR DESCRIPTION
@rmevans9 

I ended up moving a few things around here.

`reportError` is a new function in `core-client`.  So at any time, anyone can just `Reactotron.reportError(someException)`.

But if you use the `trackGlobalErrors` plugin (now horribly named), it'll override `reportError` to do symbolication.

With symbolication now on react native, we just call into the 2 functions of react native's internals slightly differently.  Seems to work great. (does seem to bomb anymore).  I think I need to double check if this is compatible with older version of React Native though.  I'll test & bump the deps if needed.

One interesting sidenote.  It looks like there's a source map resolving issue when you bomb in a generator function that calls a function in the same file.  (holy edge case).   Two ways around that is to move the non-generator functions to the end of the file (wtf?), or, like I did... create a seperate file (`./Lib/Bombsquad.js`) and just call into it from your saga.




