### PR TITLE
Unwrap dev tools action if it looks like a dev tools action

### DIFF
--- a/packages/reactotron-redux/src/create-action-tracker.js
+++ b/packages/reactotron-redux/src/create-action-tracker.js
@@ -37,15 +37,17 @@ export default (reactotron, trackerOptions = {}) => {
         // stop the timer
         const ms = elapsed()
 
+        var unwrappedAction = action.type === 'PERFORM_ACTION' && action.action ? action.action : action
+
         // action not blacklisted?
-        if (!contains(action.type, exceptions)) {
+        if (!contains(unwrappedAction.type, exceptions)) {
           // check if the app considers this important
           let important = false
           if (trackerOptions && typeof trackerOptions.isActionImportant === 'function') {
-            important = !!trackerOptions.isActionImportant(action)
+            important = !!trackerOptions.isActionImportant(unwrappedAction)
           }
 
-          reactotron.reportReduxAction(action, ms, important)
+          reactotron.reportReduxAction(unwrappedAction, ms, important)
         }
 
         return result


### PR DESCRIPTION
Not sure if there is a better way to find out if redux dev tools is turned on but here is a quick and dirty "detection" that unwraps it so Reactotron looks right even with redux dev tools on