### PR TITLE
[React Native] Fix auto-detect Android server port for newer RN versions

### DIFF
--- a/packages/reactotron-react-native/src/get-host.js
+++ b/packages/reactotron-react-native/src/get-host.js
@@ -3,15 +3,18 @@
  * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)
  */
 const getHost = (defaultHost = 'localhost') => {
+  const { remoteModuleConfig } = typeof window !== 'undefined' &&
+    window.__fbBatchedBridgeConfig || {}
   if (
-    typeof window !== 'undefined' &&
-    window.__fbBatchedBridge &&
-    window.__fbBatchedBridge.RemoteModules &&
-    window.__fbBatchedBridge.RemoteModules.AndroidConstants
-  ) {
-    const {
-      ServerHost = defaultHost
-    } = window.__fbBatchedBridge.RemoteModules.AndroidConstants
+    defaultHost !== 'localhost' && defaultHost !== '127.0.0.1' ||
+    !Array.isArray(remoteModuleConfig)
+  ) return defaultHost
+
+  const [, AndroidConstants] = remoteModuleConfig.find(config =>
+    config && config[0] === 'AndroidConstants'
+  ) || []
+  if (AndroidConstants) {
+    const { ServerHost = defaultHost } = AndroidConstants
     return ServerHost.split(':')[0]
   }
 


### PR DESCRIPTION
Looks like `__fbBatchedBridge.RemoteModules` has been removed on newer versions of RN, so currently `get-host` doesn't work.

A workaround is use `__fbBatchedBridgeConfig.remoteModuleConfig` instead.