### PR TITLE
Update config to include connect

### DIFF
--- a/docs/plugin-redux.md
+++ b/docs/plugin-redux.md
@@ -50,6 +50,7 @@ import { reactotronRedux } from 'reactotron-redux'
 Reactotron
   .configure({ name: 'React Native Demo' })
   .use(reactotronRedux()) //  <- here i am!
+  .connect() //Don't forget about me!
 ```
 
 Then, where you create your Redux store, instead of using Redux's `createStore`,


### PR DESCRIPTION
This PR adds `connect` to the redux example. I thought since it has the import statement, it should also have the call to `connect`.
### Story
I did a dumb copy paste when i came here to see how to add the redux plugin.
Then, i spent several dozens of minutes to figure out why reactotron didn't connect #285 
This could hopefully save other people those precious minutes.